### PR TITLE
Fix for issue CB-3191

### DIFF
--- a/src/config_parser.js
+++ b/src/config_parser.js
@@ -40,6 +40,22 @@ config_parser.prototype = {
             this.update();
         } else return this.doc.find('name').text;
     },
+    content: function(src) {
+        var content = this.doc.find('content');
+        if (src) {
+            content = content || new et.Element('content');
+            content.attrib.src = src;
+            this.update();
+        } else {
+            if (content === undefined) {
+                content = new et.Element('content');
+                content.attrib.src = 'index.html';
+                this.doc.getroot().append(content);
+                this.update();
+            }
+            return content.attrib.src;
+        }
+    },
     update:function() {
         fs.writeFileSync(this.path, this.doc.write({indent: 4}), 'utf-8');
     }

--- a/src/metadata/android_parser.js
+++ b/src/metadata/android_parser.js
@@ -94,6 +94,9 @@ module.exports.prototype = {
         config.access.get().forEach(function(uri) {
             android_cfg_xml.access.add(uri);
         });
+
+        // Update content
+        android_cfg_xml.content(config.content());
         
         // Update preferences
         android_cfg_xml.preference.remove();


### PR DESCRIPTION
"cordova prepare" now correctly handles the <content> tag. Android only.

https://issues.apache.org/jira/browse/CB-3191
