### PR TITLE
Fix CB3978 - support for non-semver 2 digit versions of xcodebuild

### DIFF
--- a/spec/metadata/ios_parser.spec.js
+++ b/spec/metadata/ios_parser.spec.js
@@ -75,6 +75,15 @@ describe('ios project parser', function () {
                 done();
             });
         });
+        it('should not return an error if the xcodebuild version 2 digits and not proper semver (eg: 5.0), but still satisfies the MIN_XCODE_VERSION', function(done) {
+            exec.andCallFake(function(cmd, opts, cb) {
+                cb(0, 'version 5.0');
+            });
+            platforms.ios.parser.check_requirements(proj, function(err) {
+                expect(err).toBe(false);
+                done();
+            });
+        });
     });
 
     describe('instance', function() {

--- a/src/metadata/ios_parser.js
+++ b/src/metadata/ios_parser.js
@@ -72,6 +72,9 @@ module.exports.check_requirements = function(project_root, callback) {
             callback('Xcode is (probably) not installed, specifically the command `xcodebuild` is unavailable or erroring out. Output of `'+command+'` is: ' + output);
         } else {
             var xc_version = output.split('\n')[0].split(' ')[1];
+            if(xc_version.split('.').length === 2){
+                xc_version += '.0';
+            }
             if (!semver.satisfies(xc_version, MIN_XCODE_VERSION)) {
                 callback('Xcode version installed is too old. Minimum: ' + MIN_XCODE_VERSION + ', yours: ' + xc_version);
             } else callback(false);


### PR DESCRIPTION
This adds support for 2 digit versions of xcodebuild, like the newly release 5.0. Apple doesn't provide the 3rd digit expected by semver (eg, 5.0.0). This is a different implementation of @csantanapr's similar pull (#13) with a test to go along with the change. 
