### PR TITLE
Ignore exception when plugin not installed

### DIFF
--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -157,10 +157,10 @@ describe('plugin command', function() {
                     platforms:subset
                 });
             });
-            it('should throw if plugin is not installed', function() {
+            it('should ignore exception if plugin is not installed', function() {
                 expect(function() {
                     cordova.plugin('rm', 'somethingrandom');
-                }).toThrow('Plugin "somethingrandom" not added to project.');
+                }).not.toThrow('Plugin "somethingrandom" not added to project.');
             });
 
             it('should call plugman.uninstall.uninstallPlatform for every matching installedplugin-supportedplatform pair', function() {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -149,10 +149,7 @@ module.exports = function plugin(command, targets, callback) {
                             });
                             plugman.uninstall.uninstallPlugin(target, path.join(projectRoot, 'plugins'), end);
                         } else {
-                            var err = new Error('Plugin "' + target + '" not added to project.');
-                            if (callback) callback(err);
-                            else throw err;
-                            return;
+                            events.emit('log', 'Plugin "' + target + '" not added to project.');
                         }
                     });
                 }


### PR DESCRIPTION
In my Makefile:

``` bash
rm_plugins:
    cordova plugin rm org.apache.cordova.core.media-capture
    cordova plugin rm org.apache.cordova.core.device-motion
    cordova plugin rm org.apache.cordova.core.camera
    cordova plugin rm org.apache.cordova.core.file
    cordova plugin rm org.apache.cordova.core.device-orientation
    cordova plugin rm org.apache.cordova.core.network-information
```

If any plugin doesn't installed, it will block my whole target.
