### PR TITLE
CB-5031

### DIFF
--- a/doc/help.txt
+++ b/doc/help.txt
@@ -6,6 +6,7 @@ Global Commands
 
     create <PATH> [ID] [NAME] ................ creates a cordova project in the specified PATH, with
                                                optional NAME and ID (reverse-domain-style package name)
+
     help ..................................... shows this syntax summary
 
 Project-Level Commands
@@ -14,17 +15,24 @@ Project-Level Commands
                 [{list|ls}] ................... list all installed, available and unavailable platforms
                 [{upgrade|up} <PLATFORM>] ..... upgrade the version of cordova used for a specific 
                                                PLATFORM; use after updating the CLI. 
+
     plugin(s) [{add|remove|rm} <PATH|URI>] .... add or remove a plugin from the specified PATH or URI, OR
               [{ls|list}] ..................... list all currently installed plugins
               [search <keyword1 keyword2...>] .. search the plugin registry for plugins matching the keywords
+
     prepare [PLATFORM..] ...................... copies files for specified platforms, or all platforms,
                                                 so that the project is ready to build in each SDK.
+
     compile [PLATFORM..] ...................... builds the app for specified platforms, or all platforms
+
     build [PLATFORM...] ....................... shortcut for prepare, then compile
+
     emulate [PLATFORM...] ..................... deploys app in specified (or all) platforms' emulator,
                                                 opening emulator if necessary
+
     run [PLATFORM...] ......................... deploys app on specified (or all) platform devices, which
                                                 must be properly connected and configured in each SDK
+
     serve <PLATFORM> [PORT] ................... runs a local web server for the specified platform's www/
                                                 directory, with optional port number that defaults to 8000.
                                                 (Note: you must edit the native code to reference the server.)
@@ -32,6 +40,7 @@ Project-Level Commands
 Command-line Flags/Options
 
     -v, --version ............................. prints out this utility's version
+
     -d, --verbose ............................. debug mode produces verbose log output for all activity,
                                                 including output of sub-commands cordova invokes
 


### PR DESCRIPTION
Add `plugin search` and `platform update` commands to the CLI's help text. 
I added a second commit that includes a bunch of new line breaks. I think it makes it easier to read the help text but I wanted to make it easy for the maintainer to ignore the line break additions.
