### PR TITLE
Make sure errors while preparing are reported

### DIFF
--- a/src/metadata/android_parser.js
+++ b/src/metadata/android_parser.js
@@ -212,12 +212,12 @@ module.exports.prototype = {
         var platformWww = path.join(this.path, 'assets');
         try {
             this.update_from_config(cfg);
+            this.update_www();
+            this.update_overrides();
+            this.update_staging();
         } catch(e) {
             return Q.reject(e);
         }
-        this.update_www();
-        this.update_overrides();
-        this.update_staging();
         // delete any .svn folders copied over
         util.deleteSvnFolders(platformWww);
         return Q();

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -88,6 +88,8 @@ module.exports = function prepare(options) {
                     }
                     events.emit('verbose', 'Plugin "' + plugin_id + '" is good to go.');
                 });
+            }).fail(function(e) {
+                console.error(e);
             });
         })).then(function() {
             return hooks.fire('after_prepare', options);


### PR DESCRIPTION
e.g. when android package doesn't exist under src, cordova shouldn't just silently not copy the contents of www

I have spent half a day figuring out why cordova stopped copying www to android assets.
