### PR TITLE
cordova help should return a Q. fixes CB-5070

### DIFF
--- a/src/help.js
+++ b/src/help.js
@@ -18,9 +18,11 @@
 */
 var fs = require('fs'),
     events = require('./events'),
+    Q = require('q'),
     path = require('path');
 
 module.exports = function help () {
     var raw = fs.readFileSync(path.join(__dirname, '..', 'doc', 'help.txt')).toString('utf8');
     events.emit('results', raw);
+    return Q();
 };


### PR DESCRIPTION
This is a fix for CB-5070.  when running 

```
$ cordova help
```

the help text is return fine,  but this is also return [TypeError: Cannot call method 'done' of undefined]
