### PR TITLE
CB-4748: Fail quickly if dir passed to cordova create is not empty.

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -32,36 +32,23 @@ var DEFAULT_NAME = "HelloCordova",
 
 /**
  * Usage:
- * create(dir) - creates in the specified directory
- * create(dir, name) - as above, but with specified name
- * create(dir, id, name) - you get the gist
+ * @dir - required, directory where the porject will be created.
+ * @id - app id.
+ * @name - app name.
+ * @cfg - extra config to be saved in .cordova/config.json
  **/
 // Returns a promise.
-module.exports = function create (dir, id, name) {
-    var options = [];
-
-    if (arguments.length === 0) {
+module.exports = function create (dir, id, name, cfg) {
+    if (!dir ) {
         return Q(help());
     }
 
-    var args = Array.prototype.slice.call(arguments, 0);
-
     // Massage parameters
-    if (args.length === 0) {
-        dir = process.cwd();
-        id = DEFAULT_ID;
-        name = DEFAULT_NAME;
-    } else if (args.length == 1) {
-        id = DEFAULT_ID;
-        name = DEFAULT_NAME;
-    } else if (args.length == 2) {
-        name = DEFAULT_NAME;
-    } else {
-        dir = args.shift();
-        id = args.shift();
-        name = args.shift();
-        options = args;
-    }
+    id = id || DEFAULT_ID;
+    name = name || DEFAULT_NAME;
+    cfg = cfg || {};
+    cfg.id = id;
+    cfg.name = name;
 
     // Make absolute.
     dir = path.resolve(dir);
@@ -111,13 +98,8 @@ module.exports = function create (dir, id, name) {
     shell.mkdir(path.join(hooks, 'before_prepare'));
     shell.mkdir(path.join(hooks, 'before_run'));
 
-    // Write out .cordova/config.json file with a simple json manifest
-    require('../cordova').config(dir, {
-        id:id,
-        name:name
-    });
-
-    var config_json = config.read(dir);
+    // Write out .cordova/config.json file.
+    var config_json = config(dir, cfg);
 
     // Returns a promise.
     var finalize = function(www_lib) {


### PR DESCRIPTION
Also add cfg parameter to create() for extra configuration which saved in .cordova/config.json

Should come together with the corresponding change in mca.js

This change is also on apache review board:
https://reviews.apache.org/r/14681/
