### PR TITLE
CB-5295 - Fix issue not finding platform script when in subdir

### DIFF
--- a/spec/platform.spec.js
+++ b/spec/platform.spec.js
@@ -57,9 +57,7 @@ describe('platform command', function() {
 
         fakeLazyLoad = function(id, platform, version) {
             if (platform == 'wp7' || platform == 'wp8') {
-                return Q(path.join('lib', 'wp', id, version, platform));
-            } else if (platform == 'windows8') {
-                return Q(path.join('lib', 'windows8', id, version, 'windows8'));
+                return Q(path.join('lib', 'wp', id, version));
             } else {
                 return Q(path.join('lib', platform, id, version));
             }

--- a/src/platform.js
+++ b/src/platform.js
@@ -120,7 +120,7 @@ module.exports = function platform(command, targets) {
                 .then(function() {
                     return lazy_load.based_on_config(projectRoot, plat);
                 }).then(function(libDir) {
-                    // Windows platforms are in subdirectories into repositories
+                    // Check for platforms are in subdirectories into repositories
                     if (["wp7", "wp8", "windows8", "windows81", "blackberry10"].indexOf(target) !== -1)
                         libDir = path.join(libDir, target);
 
@@ -230,7 +230,7 @@ function call_into_create(target, projectRoot, cfg, libDir, template_dir) {
         events.emit('verbose', 'Checking if platform "' + target + '" passes minimum requirements...');
         return module.exports.supports(projectRoot, target)
         .then(function() {
-            // Windows platforms are in subdirectories into repositories
+            // Check for platforms are in subdirectories into repositories
             if (["wp7", "wp8", "windows8", "windows81", "blackberry10"].indexOf(target) !== -1)
                 libDir = path.join(libDir, target);
 


### PR DESCRIPTION
Fix issue not finding platform script (create.js, update.js) when platform is in a subdirectory in its repository
- check platforms which have subdir
- append subdir to libDir for detected platforms

Platforms affected :
- Windows Phone 7
- Windows Phone 8
- Windows 8

I took the initiative to add Windows 8.1 detection as it will be hosted on Windows repository in windows81 subdirectory.
