### PR TITLE
[CB-5258] use exit library

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "xcode": "0.6.2",
     "express": "3.0.0",
     "shelljs": "0.1.2",
+    "exit": "0.1.1",
     "ncallbacks": "1.0.0",
     "request": "2.22.0",
     "ripple-emulator": "0.9.18",

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,6 +19,7 @@
 
 module.exports = function CLI(inputArgs) {
     var optimist  = require('optimist'),
+        exit      = require('exit'),
         cordova   = require('../cordova');
 
    args = optimist(inputArgs)
@@ -49,7 +50,7 @@ module.exports = function CLI(inputArgs) {
         } else {
             console.error(err);
         }
-        process.exit(1);
+        exit(1);
     });
     cordova.on('results', console.log);
 


### PR DESCRIPTION
On Windows, if you have pending bits in pipes and you exit, they
generally do not get delivered.

To avoid this, you need to change process.exit() to something
which actually ensures that buffers are flushed before it exits,
this is handled by the 'exit' module/function.
