### PR TITLE
CB-5362 blackberry parser: support local cordova-blackberry

### DIFF
--- a/src/metadata/blackberry10_parser.js
+++ b/src/metadata/blackberry10_parser.js
@@ -37,7 +37,13 @@ module.exports = function blackberry_parser(project) {
 
 // Returns a promise.
 module.exports.check_requirements = function(project_root) {
-    var lib_path = path.join(util.libDirectory, 'blackberry10', 'cordova', require('../../platforms').blackberry10.version);
+    var custom_path = config.has_custom_path(project_root, 'blackberry10');
+    var lib_path;
+    if (custom_path) {
+        lib_path = path.resolve(custom_path);
+    } else {
+        lib_path = path.join(util.libDirectory, 'blackberry10', 'cordova', require('../../platforms').blackberry10.version);
+    }
     var d = Q.defer();
     child_process.exec("\"" + path.join(lib_path, 'bin', 'check_reqs') + "\"", function(err, output, stderr) {
         if (err) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-5362

In a project directory:
.cordova/config.json:
{
  "lib": {
    "blackberry10": {
      "uri": "/path/to/cordova-blackberry/blackberry10",
      "version: "dev",
      "id": "blackberry10"
    }
  }
}
