### PR TITLE
CB-5183 WP7/8 lib path is not correctly resolved by CLI

### DIFF
--- a/src/lazy_load.js
+++ b/src/lazy_load.js
@@ -44,8 +44,7 @@ module.exports = {
     },
     // Returns a promise for the path to the lazy-loaded directory.
     custom:function(url, id, platform, version) {
-        var download_dir = (platform == 'wp7' || platform == 'wp8' ? path.join(util.libDirectory, 'wp', id, version) :
-                                                                     path.join(util.libDirectory, platform, id, version));
+        var download_dir = path.join(util.libDirectory, platform, id, version);
         if (fs.existsSync(download_dir)) {
             events.emit('verbose', id + ' library for "' + platform + '" already exists. No need to download. Continuing.');
             return Q(download_dir);
@@ -99,7 +98,14 @@ module.exports = {
                         events.emit('log', 'Download complete');
                         var entries = fs.readdirSync(download_dir);
                         var entry = path.join(download_dir, entries[0]);
-                        shell.mv('-f', path.join(entry, (platform=='blackberry10'?'blackberry10':''), '*'), download_dir);
+                        var platformsubdir = '';
+                        switch (platform) {
+                            case "blackberry10":
+                            case "wp7":
+                            case "wp8":
+                                platformsubdir = platform;
+                        }
+                        shell.mv('-f', path.join(entry, platformsubdir, '*'), download_dir);
                         shell.rm('-rf', entry);
                         d.resolve(hooker.fire('after_library_download', {
                             platform:platform,

--- a/src/platform.js
+++ b/src/platform.js
@@ -222,10 +222,6 @@ function call_into_create(target, projectRoot, cfg, libDir, template_dir) {
         events.emit('verbose', 'Checking if platform "' + target + '" passes minimum requirements...');
         return module.exports.supports(projectRoot, target)
         .then(function() {
-            // CB-5183 WP7/8 path is not correctly resolved by CLI
-            if (target == 'wp7' || target == 'wp8' || target == 'windows8') {
-                libDir =  path.join(libDir, target);
-            }            
             // Create a platform app using the ./bin/create scripts that exist in each repo.
             // Run platform's create script
             var bin = path.join(libDir, 'bin', 'create');


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-5183
- Refactor BlackBerry's git repo root is not cordova root code
- Share it with Windows / Windows Phone

This isn't tested, but in theory it should do the right thing...
