### PR TITLE
fix args[0] bug, corodva -> cordova

### DIFF
--- a/e2e/fixtures/platforms/android/cordova/lib/build.js
+++ b/e2e/fixtures/platforms/android/cordova/lib/build.js
@@ -80,7 +80,7 @@ module.exports.get_apk = function() {
 }
 
 module.exports.help = function() {
-    console.log('Usage: ' + path.relative(process.cwd(), path.join(ROOT, 'corodva', 'build')) + ' [build_type]');
+    console.log('Usage: ' + path.relative(process.cwd(), path.join(ROOT, 'cordova', 'build')) + ' [build_type]');
     console.log('Build Types : ');
     console.log('    \'--debug\': Default build, will build project in using ant debug');
     console.log('    \'--release\': will build project using ant release');

--- a/e2e/fixtures/platforms/android/cordova/lib/clean.js
+++ b/e2e/fixtures/platforms/android/cordova/lib/clean.js
@@ -37,7 +37,7 @@ module.exports.run = function() {
 }
 
 module.exports.help = function() {
-    console.log('Usage: ' + path.relative(process.cwd(), process.argv[1]));
+    console.log('Usage: ' + path.relative(process.cwd(), path.join(ROOT, 'cordova', 'clean')));
     console.log('Cleans the project directory.');
     process.exit(0);
 }

--- a/e2e/fixtures/platforms/android/cordova/lib/log.js
+++ b/e2e/fixtures/platforms/android/cordova/lib/log.js
@@ -37,7 +37,7 @@ module.exports.run = function() {
 }
 
 module.exports.help = function() {
-    console.log('Usage: ' + path.relative(process.cwd(), path.join(ROOT, 'corodva', 'log')));
+    console.log('Usage: ' + path.relative(process.cwd(), path.join(ROOT, 'cordova', 'log')));
     console.log('Gives the logcat output on the command line.');
     process.exit(0);
 }

--- a/e2e/fixtures/platforms/android/cordova/lib/run.js
+++ b/e2e/fixtures/platforms/android/cordova/lib/run.js
@@ -22,7 +22,8 @@
 var path  = require('path'),
     build = require('./build'),
     emulator = require('./emulator'),
-    device   = require('./device');
+    device   = require('./device'),
+    ROOT = path.join(__dirname, '..', '..');
 
 /*
  * Runs the application on a device if availible.
@@ -110,7 +111,7 @@ var path  = require('path'),
 }
 
 module.exports.help = function() {
-    console.log('Usage: ' + path.relative(process.cwd(), args[0]) + ' [options]');
+    console.log('Usage: ' + path.relative(process.cwd(), path.join(ROOT, 'cordova', 'run')) + ' [options]');
     console.log('Build options :');
     console.log('    --debug : Builds project in debug mode');
     console.log('    --release : Builds project in release mode');


### PR DESCRIPTION
run --help gives the following error

``` bash
lms@zenb00k|12:48|~ $ /home/lms/src/multiscreen/platforms/android/cordova/run --help

/home/lms/src/multiscreen/platforms/android/cordova/lib/run.js:113
    console.log('Usage: ' + path.relative(process.cwd(), args[0]) + ' [options
                                                         ^
ReferenceError: args is not defined
    at Object.module.exports.help (/home/lms/src/multiscreen/platforms/android/cordova/lib/run.js:113:58)
    at Object.<anonymous> (/home/lms/src/multiscreen/platforms/android/cordova/run:29:9)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3
```
