### PR TITLE
windows8. fixes version number parsing logic

### DIFF
--- a/src/metadata/windows8_parser.js
+++ b/src/metadata/windows8_parser.js
@@ -296,8 +296,8 @@ module.exports.prototype = {
 
     // Adjust version number as per CB-5337 Windows8 build fails due to invalid app version        
     fixConfigVersion: function (version) {
-        if(version && version.match(/\.d/g)) {
-            var numVersionComponents = version.match(/\.d/g).length + 1;
+        if(version && version.match(/\.\d/g)) {
+            var numVersionComponents = version.match(/\.\d/g).length + 1;
             while (numVersionComponents++ < 4) {
                 version += '.0';
             }


### PR DESCRIPTION
it does not work now, could be tested by running the following in js console
before
'0.0.1'.match(/.d/g).length
after
'0.0.1'.match(/.\d/g).length
