### PR TITLE
util.isRootDir check for platforms/

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -28,9 +28,13 @@ shell.mkdir('-p', lib_path);
 
 function isRootDir(dir) {
     if (fs.existsSync(path.join(dir, 'www'))) {
-        // For sure is.
         if (fs.existsSync(path.join(dir, 'config.xml'))) {
-            return 2;
+            // For sure is.
+            if (fs.existsSync(path.join(dir, 'platforms'))) {
+                return 2;
+            } else {
+                return 1;
+            }
         }
         // Might be (or may be under platforms/).
         if (fs.existsSync(path.join(dir, 'www', 'config.xml'))) {


### PR DESCRIPTION
platforms/ubuntu contains config.xml, so extra check is required
