### PR TITLE
CB-6211 [CLI] 'cordova info' command fixed

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -39,7 +39,7 @@ module.exports = function info() {
 
     output = raw.map(function(line) {
         if(line.match('    %') ) {
-            var type = line.substr(5),
+            var type = (line.substr(5)).replace("\r",""),
                 out = "";
 
             switch(type) {
@@ -100,7 +100,7 @@ function doPlatforms( projectRoot ){
         for(i=0; i<platforms.length; i++){
             output += raw.map(function(line) {
                 if(line.match('    %') ) {
-                    var type = line.substr(5),
+                    var type = (line.substr(5)).replace("\r",""),
                         out = "";
 
                     switch(type) {


### PR DESCRIPTION
Reference to JIRA issue CB-6211, the cordova info command it doesn't
work.
Cause by:  Carriage return or new line.

Fixed removing that carriage return from the var 'type'.
