### PR TITLE
Fix ConfigParser.getPreference error + tests

### DIFF
--- a/spec/ConfigParser.spec.js
+++ b/spec/ConfigParser.spec.js
@@ -72,5 +72,13 @@ describe('config.xml parser', function () {
                 expect(cfg.name()).toEqual('this.is.bat.country');
             });
         });
+        describe('preference', function() {
+            it('should get value of existing preference', function() {
+                expect(cfg.getPreference('fullscreen')).toEqual('true');
+            });
+            it('should get undefined as non existing preference', function() {
+                expect(cfg.getPreference('zimzooo!')).toEqual(undefined);
+            });
+        });
     });
 });

--- a/src/ConfigParser.js
+++ b/src/ConfigParser.js
@@ -82,12 +82,12 @@ ConfigParser.prototype = {
     getPreference: function(name) {
         var preferences = this.doc.findall('preference');
         var ret = null;
-        for (var i = 0, ii = preferences.length; i < ii; ++i) {
+        preferences.forEach(function (preference) {
             // Take the last one that matches.
-            if (preferences[i].attrib.name.toLowerCase() === name) {
-                ret = a.attrib.value;
+            if (preference.attrib.name.toLowerCase() === name) {
+                ret = preference.attrib.value;
             }
-        }
+        });
         return ret;
     },
     write:function() {


### PR DESCRIPTION
Was getting the following error:

```
ReferenceError: a is not defined
    at Object.ConfigParser.getPreference
        (/home/alfred/repos/cordova-cli/src/ConfigParser.js:88:23)
```
