### PR TITLE
Print stack trace when possible on `prepare` error

### DIFF
--- a/src/prepare.js
+++ b/src/prepare.js
@@ -112,7 +112,7 @@ exports = module.exports = function prepare(options) {
 
                 return parser.update_project(cfg);
             }).fail(function(e) {
-                console.error(e);
+                console.error(e.stack || e);
             });
         })).then(function() {
             return hooks.fire('after_prepare', options);


### PR DESCRIPTION
When I got the error #138, it took me a little time to find the source of the error. This would be very helpful for developers of this project.

Before it used to be like this:

```
alfred@alFolio:~/repos/carpool/client$ cordova prepare
[ReferenceError: a is not defined]
alfred@alFolio:~/repos/carpool/client$
```

Now it's like this:

```
alfred@alFolio:~/repos/carpool/client$ cordova prepare
ReferenceError: a is not defined
    at Object.ConfigParser.getPreference (/home/alfred/repos/cordova-cli/src/ConfigParser.js:88:23)
    at Object.module.exports.findOrientationPreference (/home/alfred/repos/cordova-cli/src/metadata/android_parser.js:52:26)
    at Object.module.exports.update_from_config (/home/alfred/repos/cordova-cli/src/metadata/android_parser.js:84:36)
    at Object.module.exports.update_project (/home/alfred/repos/cordova-cli/src/metadata/android_parser.js:167:18)
    at /home/alfred/repos/cordova-cli/src/prepare.js:113:31
    at _fulfilled (/home/alfred/repos/cordova-cli/node_modules/q/q.js:798:54)
    at self.promiseDispatch.done (/home/alfred/repos/cordova-cli/node_modules/q/q.js:827:30)
    at Promise.promise.promiseDispatch (/home/alfred/repos/cordova-cli/node_modules/q/q.js:760:13)
    at /home/alfred/repos/cordova-cli/node_modules/q/q.js:821:14
    at flush (/home/alfred/repos/cordova-cli/node_modules/q/q.js:108:17)
alfred@alFolio:~/repos/carpool/client$ 
```
