### PR TITLE
Update xml-helpers.js

### DIFF
--- a/src/xml-helpers.js
+++ b/src/xml-helpers.js
@@ -110,7 +110,7 @@ module.exports = {
     parseElementtreeSync: function (filename) {
         var contents = fs.readFileSync(filename, 'utf-8');
         if(contents) {
-            contents = contents.replace(/^\uFEFF/, ''); //Windows is the BOM
+            contents = contents.substring(contents.indexOf("<")); //Windows is the BOM
         }
         return new et.ElementTree(et.XML(contents));
     }


### PR DESCRIPTION
On Windows Desktop, "Non-whitespace before first tag." error occurs by an old code.
