### PR TITLE
CB-6415 [Blackberry] added path.join at check requirements function

### DIFF
--- a/src/metadata/blackberry10_parser.js
+++ b/src/metadata/blackberry10_parser.js
@@ -41,7 +41,7 @@ module.exports.check_requirements = function(project_root) {
     var custom_path = config.has_custom_path(project_root, 'blackberry10');
     var lib_path;
     if (custom_path) {
-        lib_path = path.resolve(custom_path);
+        lib_path = path.join(custom_path, 'blackberry10');
     } else {
         lib_path = path.join(util.libDirectory, 'blackberry10', 'cordova', require('../../platforms').blackberry10.version);
     }


### PR DESCRIPTION
I've tracked down this problem, and I've found it.
Changed path.resolve for custom path, for path.join, is required search
for 'blackberry10' under 'cordova-blackberry' [cloned repository name].
