### PR TITLE
android-parser: Add launch-mode preference

### DIFF
--- a/src/ConfigParser.js
+++ b/src/ConfigParser.js
@@ -90,7 +90,7 @@ ConfigParser.prototype = {
         var ret = null;
         preferences.forEach(function (preference) {
             // Take the last one that matches.
-            if (preference.attrib.name.toLowerCase() === name) {
+            if (preference.attrib.name.toLowerCase() === name.toLowerCase()) {
                 ret = preference.attrib.value;
             }
         });

--- a/src/metadata/android_parser.js
+++ b/src/metadata/android_parser.js
@@ -59,6 +59,17 @@ module.exports.prototype = {
         return ret;
     },
 
+    findAndroidLaunchModePreference: function(config) {
+        var ret = config.getPreference('AndroidLaunchMode');
+        var valid = ['standard', 'singleTop', 'singleTask', 'singleInstance'].indexOf(ret) !== -1;
+        if (ret && !valid) {
+            events.emit('warn', 'Unknown value for launchMode preference: ' + ret);
+            ret = null;
+        }
+
+        return ret;
+    },
+
     update_from_config:function(config) {
         if (config instanceof ConfigParser) {
         } else throw new Error('update_from_config requires a ConfigParser object');
@@ -83,10 +94,11 @@ module.exports.prototype = {
         var orig_pkg = manifest.getroot().attrib.package;
         manifest.getroot().attrib.package = pkg;
 
+        var act = manifest.getroot().find('./application/activity');
+
         // Set the orientation in the AndroidManifest
         var orientationPref = this.findOrientationPreference(config);
         if (orientationPref) {
-            var act = manifest.getroot().find('./application/activity');
             switch (orientationPref) {
                 case 'default':
                     delete act.attrib["android:screenOrientation"];
@@ -97,6 +109,14 @@ module.exports.prototype = {
                 case 'landscape':
                     act.attrib["android:screenOrientation"] = 'landscape';
             }
+        }
+
+        // Set android:launchMode in AndroidManifest
+        var androidLaunchModePref = this.findAndroidLaunchModePreference(config);
+        if (androidLaunchModePref) {
+            act.attrib["android:launchMode"] = androidLaunchModePref;
+        } else { // User has (explicitly) set an invalid value for AndroidLaunchMode preference
+            delete act.attrib["android:launchMode"]; // use Android default value (standard)
         }
 
         // Write out AndroidManifest.xml


### PR DESCRIPTION
This allows users to set `android:launchMode` from **config.xml**

Related:
https://groups.google.com/forum/#!topic/phonegap/8E5C6phqQA4
https://groups.google.com/forum/#!topic/phonegap/R08vOZNm580
