### PR TITLE
CB-2606 Icons support for iOS, Android, BB10, WP8, Win8, FxOS

### DIFF
--- a/spec/test-config.xml
+++ b/spec/test-config.xml
@@ -18,4 +18,9 @@
     <access origin="*" />
     <preference name="fullscreen" value="true" />
     <preference name="webviewbounce" value="true" />
+    <icon id="icon" src="icon.png" />
+    <icon id="logo" src="logo.png" width="255" height="255" />
+    <platform name="android">
+        <icon src="logo-android.png" width="255" height="255" density="mdpi" />
+    </platform>    
 </widget>

--- a/src/ConfigParser.js
+++ b/src/ConfigParser.js
@@ -96,6 +96,65 @@ ConfigParser.prototype = {
         });
         return ret;
     },
+    /**
+     * Returns all icons for the platform specified.
+     * @param  {String} platform The platform.
+     * @return {Array} Icons for the platform specified.
+     */
+    getIcons: function(platform) {
+        var ret = [];
+            iconElements = [];
+
+        if (platform) { // platform specific icons
+            this.doc.findall('platform[@name=\'' + platform + '\']/icon').forEach(function(elt){
+                elt.platform = platform; // mark as platform specific icon
+                iconElements.push(elt)
+            });
+        }
+        // root level icons
+        iconElements = iconElements.concat(this.doc.findall('icon'));
+        // parse icon elements
+        iconElements.forEach(function (elt) {
+            var icon = {};
+            icon.src = elt.attrib.src;
+            icon.density = elt.attrib['density'] || elt.attrib['cdv:density'] || elt.attrib['gap:density'];
+            icon.platform = elt.platform || null; // null means icon represents default icon (shared between platforms)
+            icon.width = elt.attrib.width;
+            icon.height = elt.attrib.height;
+            // If one of width or Height is undefined, assume they are equal.
+            icon.width = icon.width || icon.height;
+            icon.height = icon.height || icon.width;
+
+            // default icon
+            if (!icon.width && !icon.height && !icon.density) {
+                ret.defaultIcon = icon;  
+            }
+            ret.push(icon);
+        });
+
+        /**
+         * Returns icon with specified width and height
+         * @param  {number} w  Width of icon
+         * @param  {number} h  Height of icon
+         * @return {Icon}      Icon object or null if not found
+         */
+        ret.getIconBySize = function(w, h){
+            // If only one of width and height is given
+            // then we assume that they are equal.
+            var width = w || h, height = h || w;
+            for (var idx in this) {
+                var icon = this[idx];
+                if (width == icon.width && height == icon.width) return icon;
+            }
+            return null;
+        };
+        /** Returns default icons */
+        ret.getDefault = function() {
+            return ret.defaultIcon;
+        }
+
+        return ret;
+    },
     write:function() {
         fs.writeFileSync(this.path, this.doc.write({indent: 4}), 'utf-8');
     }

--- a/src/metadata/android_parser.js
+++ b/src/metadata/android_parser.js
@@ -70,6 +70,98 @@ module.exports.prototype = {
         fs.writeFileSync(this.strings, strings.write({indent: 4}), 'utf-8');
         events.emit('verbose', 'Wrote out Android application name to "' + name + '"');
 
+        var icons = config.getIcons('android');
+        // if there are icon elements in config.xml
+        if (icons) {
+          var haveSeenDefaultIcon = false;
+          var iconCount = 0;
+          var android_icons = {};
+          var projectRoot = util.isCordova(this.path);
+          var default_icon;
+          var max_size;
+          var max_density;
+          // http://developer.android.com/design/style/iconography.html
+          var densities = {
+            "ldpi" : 36,
+            "mdpi" : 48,
+            "hdpi" : 72,
+            "xhdpi" : 96
+          };
+          for (var i=0; i<icons.length; i++) {
+            var icon = icons[i];
+            var destfilepath;
+            var size = icon.width;
+            if (!size) {
+              size = icon.height;
+            }
+            if (!size && !icon.density) {
+              if (default_icon) {
+                  events.emit('verbose', "more than one default icon: " + JSON.stringify(icon)); 
+              } else {
+                  default_icon = icon;
+              }
+            } else {
+              var parseIcon = function(icon, icon_size, size, density) {
+                // if density is explicitly defined, no need to calculate it from width/height
+                if (icon.density) {
+                    android_icons[icon.density] = icon;
+                    return;
+                }
+
+                var i = parseInt(icon_size);
+                if (size == parseInt(icon_size)) {
+                  var previous = android_icons[density];
+                  if (previous) {
+                    // already have that density. platform rules
+                    if (!previous.platform) {
+                      android_icons[density] = icon;
+                    } // else already have a platform icon of that density
+                  } else {
+                    android_icons[density] = icon;
+                  }
+                  android_icons[density] = icon;
+                  if (!max_size) {
+                    max_size = size;
+                    max_density = density;
+                  } else {
+                    if (max_size < size) {
+                      max_size = size
+                      max_density = density;
+                    }
+                  }
+                }
+              };
+              for (var density in densities) {
+                parseIcon(icon, size, densities[density], density);
+              }
+            } 
+          }
+
+          var copyIcon = function(density) {
+            var srcfilepath;
+            var destfilepath = path.join(this.path, 'res', 'drawable-'+density, 'icon.png');
+            if (android_icons[density]) {
+              srcfilepath = path.join(projectRoot, android_icons[density].src);
+            } else {
+              if (default_icon) {
+                srcfilepath = path.join(projectRoot, default_icon.src);
+              } else {
+                if (max_density) {
+                  srcfilepath = path.join(projectRoot, android_icons[max_density].src);
+                } else {
+                  events.emit('verbose', 'no icon found matching Android typical densities');
+                }
+              }
+            }
+            events.emit('verbose', 'Copying icon from ' + srcfilepath + ' to ' + destfilepath);
+            shell.cp('-f', srcfilepath, destfilepath);
+          }.bind(this);
+          for (var density in densities) {
+            copyIcon(density);
+          }
+
+        }
+
         var manifest = xml.parseElementtreeSync(this.manifest);
         // Update the version by changing the AndroidManifest android:versionName
         var version = config.version();

--- a/src/metadata/blackberry10_parser.js
+++ b/src/metadata/blackberry10_parser.js
@@ -58,8 +58,32 @@ module.exports.check_requirements = function(project_root) {
 
 module.exports.prototype = {
     update_from_config:function(config) {
-        if (config instanceof ConfigParser) {
-        } else throw new Error('update_from_config requires a ConfigParser object');
+        var projectRoot = util.isCordova(this.path),
+            resDir = path.join(this.path, 'platform_www', 'res'),
+            icons,
+            i;
+
+        if (!config instanceof ConfigParser) {
+            throw new Error('update_from_config requires a ConfigParser object');
+        }
+
+        shell.rm('-rf', resDir);
+        shell.mkdir(resDir);
+
+        icons = config.getIcons('blackberry10');
+        if (icons) {
+            for (i = 0; i < icons.length; i++) {
+                var src = path.join(projectRoot, icons[i].src),
+                    dest = path.join(this.path, 'platform_www', icons[i].src),
+                    destFolder = path.join(dest, '..');
+                
+                if (!fs.existsSync(destFolder)) {
+                    shell.mkdir(destFolder); // make sure target dir exists
+                }
+                events.emit('verbose', 'Copying icon from ' + src + ' to ' + dest);
+                shell.cp('-f', src, dest);
+            }
+        }
     },
 
     // Returns a promise.

--- a/src/metadata/firefoxos_parser.js
+++ b/src/metadata/firefoxos_parser.js
@@ -20,6 +20,7 @@ var fs = require('fs'),
     path = require('path'),
     shell = require('shelljs'),
     util = require('../util'),
+    events = require('../events'),
     Q = require('q'),
     ConfigParser = require('../ConfigParser'),
     config = require('../config');
@@ -56,6 +57,26 @@ module.exports.prototype = {
                 installs_allowed_from: ["*"]
             };
         }
+
+        // Update icons
+        var icons = config.getIcons('firefoxos');
+        var platformRoot = this.path;
+        var appRoot = util.isCordova(platformRoot);
+
+        // http://www.mozilla.org/en-US/styleguide/products/firefox-os/icons/
+        var platformIcons = [
+            {dest: "www/img/logo.png", width: 60, height: 60}
+        ];
+
+        platformIcons.forEach(function (item) {
+            icon = icons.getIconBySize(item.width, item.height) || icons.getDefault();
+            if (icon){
+                var src = path.join(appRoot, icon.src),
+                    dest = path.join(platformRoot, item.dest);
+                events.emit('verbose', 'Copying icon from ' + src + ' to ' + dest);
+                shell.cp('-f', src, dest);
+            }
+        });
 
         manifest.version = version;
         manifest.name = name;

--- a/src/metadata/ios_parser.js
+++ b/src/metadata/ios_parser.js
@@ -76,6 +76,38 @@ module.exports.prototype = {
         fs.writeFileSync(plistFile, info_contents, 'utf-8');
         events.emit('verbose', 'Wrote out iOS Bundle Identifier to "' + pkg + '"');
         events.emit('verbose', 'Wrote out iOS Bundle Version to "' + version + '"');
+        
+        // Update icons
+        var icons = config.getIcons('ios');
+        var platformRoot = this.cordovaproj;
+        var appRoot = util.isCordova(platformRoot);
+
+        var platformIcons = [
+            {dest: "icon-60.png", width: 60, height: 60},
+            {dest: "icon-60@2x.png", width: 120, height: 120},
+            {dest: "icon-76.png", width: 76, height: 76},
+            {dest: "icon-76@2x.png", width: 152, height: 152},
+            {dest: "icon-small.png", width: 29, height: 29},
+            {dest: "icon-small@2x.png", width: 58, height: 58},
+            {dest: "icon-40.png", width: 40, height: 40},
+            {dest: "icon-40@2x.png", width: 80, height: 80},
+            {dest: "icon.png", width: 57, height: 57},
+            {dest: "icon@2x.png", width: 114, height: 114},
+            {dest: "icon-72.png", width: 72, height: 72},
+            {dest: "icon-72@2x.png", width: 144, height: 144},
+            {dest: "icon-50.png", width: 50, height: 50},
+            {dest: "icon-50@2x.png", width: 100, height: 100}
+        ];
+
+        platformIcons.forEach(function (item) {
+            icon = icons.getIconBySize(item.width, item.height) || icons.getDefault();
+            if (icon){
+                var src = path.join(appRoot, icon.src),
+                    dest = path.join(platformRoot, 'Resources/icons/', item.dest);
+                events.emit('verbose', 'Copying icon from ' + src + ' to ' + dest);
+                shell.cp('-f', src, dest);
+            }
+        });
 
         if (name != this.originalName) {
             // Update product name inside pbxproj file

--- a/src/metadata/windows8_parser.js
+++ b/src/metadata/windows8_parser.js
@@ -165,6 +165,28 @@ module.exports.prototype = {
         //Write out manifest
         fs.writeFileSync(this.manifest_path, manifest.write({indent: 4}), 'utf-8');
 
+        // Update icons
+        var icons = config.getIcons('windows8');
+        var platformRoot = this.windows8_proj_dir;
+        var appRoot = util.isCordova(platformRoot);
+
+        // Icons, that should be added to platform
+        var platformIcons = [
+            {dest: "images/logo.png", width: 150, height: 150},
+            {dest: "images/smalllogo.png", width: 30, height: 30},
+            {dest: "images/storelogo.png", width: 50, height: 50},
+        ];
+
+        platformIcons.forEach(function (item) {
+            icon = icons.getIconBySize(item.width, item.height) || icons.getDefault();
+            if (icon){
+                var src = path.join(appRoot, icon.src),
+                    dest = path.join(platformRoot, item.dest);
+                events.emit('verbose', 'Copying icon from ' + src + ' to ' + dest);
+                shell.cp('-f', src, dest);
+            }
+        });
+
     },
     // Returns the platform-specific www directory.
     www_dir:function() {

--- a/src/metadata/wp8_parser.js
+++ b/src/metadata/wp8_parser.js
@@ -140,6 +140,29 @@ module.exports.prototype = {
 
          //Write out manifest
          fs.writeFileSync(this.manifest_path, manifest.write({indent: 4}), 'utf-8');
+
+        // Update icons
+        var icons = config.getIcons('wp8');
+        var platformRoot = this.wp8_proj_dir;
+        var appRoot = util.isCordova(platformRoot);
+
+        // icons, that should be added to platform
+        // @param dest {string} Path to copy icon to, relative to platform root
+        var platformIcons = [
+            {dest: "ApplicationIcon.png", width: 99, height: 99},
+            {dest: "Background.png", width: 159, height: 159},
+        ];
+
+        platformIcons.forEach(function (item) {
+            icon = icons.getIconBySize(item.width, item.height) || icons.getDefault();
+            if (icon){
+                var src = path.join(appRoot, icon.src),
+                    dest = path.join(platformRoot, item.dest);
+                events.emit('verbose', 'Copying icon from ' + src + ' to ' + dest);
+                shell.cp('-f', src, dest);
+            }
+        });
+
     },
     // Returns the platform-specific www directory.
     www_dir:function() {


### PR DESCRIPTION
Based on original version and PR made by @AxelNennker: https://github.com/apache/cordova-cli/pull/126

The following platforms are supported: iOS, Android, BB10, WP8, Win8, FxOS
Updated documentation can be found here: https://github.com/apache/cordova-docs/pull/201/files
Sample configuration file: https://gist.github.com/sgrebnov/9949313
