### PR TITLE
Revert "CB-6267 Windows8. Apply BackgroundColor from config.xml"

### DIFF
--- a/src/metadata/windows8_parser.js
+++ b/src/metadata/windows8_parser.js
@@ -118,10 +118,6 @@ module.exports.prototype = {
                 if(displayName != name) {
                     visualElems['attrib']['DisplayName'] = name;
                 }
-                var bgColor = config.getPreference('backgroundcolor');
-                if (bgColor) {
-                    visualElems.attrib.BackgroundColor = bgColor;
-                }
             }
             else {
                 throw new Error('update_from_config expected a valid package.appxmanifest' +


### PR DESCRIPTION
This reverts commit 56a7893362421b49e782521698057ae40d7c8d3a.

Reverted because bgColor logic moved to cordova-windows template: see https://github.com/apache/cordova-windows/pull/28
