### PR TITLE
Windows 8.1 update breaks app manifest parser

### DIFF
--- a/src/metadata/windows8_parser.js
+++ b/src/metadata/windows8_parser.js
@@ -111,7 +111,7 @@ module.exports.prototype = {
                 app['attrib']['Id'] = pkgName;
             }
 
-            var visualElems = manifest.find('.//VisualElements');
+            var visualElems = manifest.find('.//VisualElements') || manifest.find('.//m2:VisualElements');
 
             if(visualElems) {
                 var displayName = visualElems['attrib']['DisplayName'];


### PR DESCRIPTION
The powers-that-be at Microsoft decided to add another namespace to the package.appxmanifest when I updated my Windows 8 app to Windows 8.1. The Package/Applications/Application/VisualElements element now has a namespace prefix of "m2:" which causes an error during project preparation. This commit contains a quick, low-risk update to accommodate that change.
