### PR TITLE
CB-6976 Add support for Windows Universal apps (Windows 8.1 and WP 8.1)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -165,6 +165,20 @@ function cli(inputArgs) {
             throw new CordovaError(msg)
         }
 
+        // CB-6976 Windows Universal Apps. Allow mixing windows and windows8 aliases
+        opts.platforms = opts.platforms.map(function(platform) {
+            // allow using old windows8 alias for new unified windows platform
+            if (platform == 'windows8' && require('fs').existsSync('platforms/windows')) {
+                return 'windows';
+            } 
+            // allow using new windows alias for old windows8 platform
+            if (platform == 'windows' && !require('fs').existsSync('platforms/windows') 
+                && require('fs').existsSync('platforms/windows8')) {
+                return 'windows8';
+            }
+            return platform;
+        })
+
         // Reconstruct the args to be passed along to platform scripts.
         // This is an ugly temporary fix. The code spawning or otherwise
         // calling into platform code should be dealing with this based


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6976
- Allow using new windows alias to work with old windows8 platform
- Allow using old windows8 alias to work with new windows universal apps
