### PR TITLE
Add symbolic link option to for cordova plugins

### DIFF
--- a/doc/plugin.txt
+++ b/doc/plugin.txt
@@ -16,6 +16,8 @@ Manage project plugins
 
         [--noregistry] ............................ don't search the registry for plugins
 
+        [--link] .................................. create a symbolic link to the plugin instead of copying files
+
     remove <pluginid> [...] ....................... remove plugins with the given IDs
 
     list .......................................... list currently installed plugins

--- a/src/cli.js
+++ b/src/cli.js
@@ -71,6 +71,7 @@ function cli(inputArgs) {
         , 'link-to' : path
         , 'searchpath' : String
         , 'variable' : Array
+        , 'link': Boolean
         // Flags to be passed to `cordova build/run/emulate`
         , 'debug' : Boolean
         , 'release' : Boolean
@@ -282,6 +283,7 @@ function cli(inputArgs) {
                             , usegit : args.usegit
                             , cli_variables : cli_vars
                             , browserify: args.browserify || false
+                            , link: args.link || false
                             };
         cordova.raw[cmd](subcommand, targets, download_opts).done();
     }


### PR DESCRIPTION
Requires associated cordova-lib change: https://github.com/apache/cordova-lib/pull/78
