### PR TITLE
CB-7636 Allow using --nobuild flag without screaning

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -80,6 +80,7 @@ function cli(inputArgs) {
         , 'emulator': Boolean
         , 'target' : String
         , 'browserify': Boolean
+        , 'nobuild': Boolean
         };
 
     var shortHands =
@@ -205,7 +206,7 @@ function cli(inputArgs) {
         // calling into platform code should be dealing with this based
         // on the parsed args object.
         var downstreamArgs = [];
-        var argNames = [ 'debug', 'release', 'device', 'emulator' ];
+        var argNames = [ 'debug', 'release', 'device', 'emulator', 'nobuild'];
         argNames.forEach(function(flag) {
             if (args[flag]) {
                 downstreamArgs.push('--' + flag);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-7636

Currently ‘--nobuild’ param requires – screening

So this skips --nobuild flag
λ cordova run wp8 --nobuild --target="dummy"

Whereas the following works correct
λ cordova run wp8 --target="dummy" -- --nobuild

This is inconsistent with other run options (--device, --target, --emulator) which don’t not require screening.
