### PR TITLE
CB-8129 Add test coverage report generation to core cordova tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage
 node_modules
 npm-debug.log
 temp

--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ The directory structure of KewlApp now looks like this:
 
     npm test
 
+## Get test coverage reports
+
+    npm run cover
+
 ## TO-DO + Issues
 
 Please check [Cordova issues with the CLI Component](http://issues.cordova.io). If you find issues with this tool, please be so kind as to include relevant information needed to debug issues such as:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "cordova": "./bin/cordova"
   },
   "scripts": {
-    "test": "jasmine-node --captureExceptions --color spec"
+    "test": "node node_modules/jasmine-node/bin/jasmine-node --captureExceptions --color spec",
+    "cover": "node node_modules/istanbul/lib/cli.js cover --root src --print detail node_modules/jasmine-node/bin/jasmine-node -- spec"
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,7 @@
     "underscore":"1.7.0"
   },
   "devDependencies": {
+    "istanbul": "^0.3.4",
     "jasmine-node": "1.14.5"
   },
   "author": "Anis Kadri",

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -30,9 +30,6 @@ describe("cordova cli", function () {
         // logging events registered as a result of the "--verbose" flag in
         // CLI testing below would cause lots of logging messages printed out by other specs.
         spyOn(events, "on");
-        // Each call to cli() registers another listener for uncaughtException.
-        // This results in a warning when too many of them are registered.
-        process.removeAllListeners();
         spyOn(console, 'log');
     });
 


### PR DESCRIPTION
This implements [CB-8129](https://issues.apache.org/jira/browse/CB-8129) and adds `npm run cover` command that generates a test coverage report under `coverage` directory and prints coverage summary to console.
