### PR TITLE
Grunt "retire" task added

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,42 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+module.exports = function(grunt) {
+
+    grunt.initConfig({
+
+        pkg : grunt.file.readJSON('package.json'),
+
+        // Look for security fixes in dependencies
+        retire : {
+            js      : ['cordova.js', 'Gruntfile.js', 'spec/*.js', 'src/*.js'],
+            node    : ['./'],
+            options : {
+                verbose        : true,
+                packageOnly    : true,
+                jsRepository   : 'https://raw.github.com/bekk/retire.js/master/repository/jsrepository.json',
+                nodeRepository : 'https://raw.github.com/bekk/retire.js/master/repository/npmrepository.json'
+            }
+        }
+
+    });
+
+    grunt.loadNpmTasks('grunt-retire');
+
+};

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   },
   "devDependencies": {
     "istanbul": "^0.3.4",
+    "grunt": "0.4.5",
+    "grunt-retire": "0.3.7",
     "jasmine-node": "1.14.5"
   },
   "author": "Anis Kadri",


### PR DESCRIPTION
All dependencies are fine now but I think it could be a good idea to automate the check process.

![cordovacliretire](https://cloud.githubusercontent.com/assets/2753855/5693266/a9261306-9915-11e4-8b51-7df8a94d69b0.png)
