### PR TITLE
CB-8790 - Add information about Firefox OS to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Check out the [Getting Started guides](http://cordova.apache.org/docs/en/edge/) 
 - Amazon Fire OS
 - Android
 - BlackBerry 10
+- Firefox OS
 - iOS
 - Ubuntu
 - Windows Phone 8
@@ -324,4 +325,4 @@ This bug report documents the issue and solutions for it: https://bugs.launchpad
 
 ## Firefox OS
 
-Firefox OS does not include the ability to emulate, run and serve. After building, you will have to open the firefoxos platform directory of your app in the App Manager that comes with every firefox browser. 
+Firefox OS does not include the ability to emulate, run and serve. After building, you will have to open the `firefoxos` platform directory of your app in the [WebIDE](https://developer.mozilla.org/docs/Tools/WebIDE) that comes with every Firefox browser. You can keep this window open and click on the "play" button every time you finished building your app.


### PR DESCRIPTION
- Add Firefox OS as supported platform
- Change "App Manager" to the newer "WebIDE"

https://issues.apache.org/jira/browse/CB-8790