### PR TITLE
CB-8993 Plugin restore ignores search path

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -180,7 +180,8 @@ function cli(inputArgs) {
         options: [],
         verbose: args.verbose || false,
         silent: args.silent || false,
-        browserify: args.browserify || false
+        browserify: args.browserify || false,
+        searchpath : args.searchpath
     };
 
 


### PR DESCRIPTION
Allows searchpath to be passed with the cordova prepare command.