### PR TITLE
CB-9114: Deprecating the --usegit flag

### DIFF
--- a/doc/platform.txt
+++ b/doc/platform.txt
@@ -5,7 +5,10 @@ Synopsis
 Manage project platforms
 
     add <plat-spec> [...].............. add specified platforms
-        --usegit ...................... retrieve from git instead of npm registry
+        --usegit ...................... [WARNING: This flag has been deprecated.]
+                                        [Instead, please use: `cordova platform add git-url#custom-branch`.] 
+                                        [e.g: cordova platform add https://github.com/apache/cordova-android.git#2.4.0]
+                                        retrieve from git instead of npm registry
 
         --save ........................ save specified platforms into config.xml after installing them
 


### PR DESCRIPTION
CB-9114: Deprecating the --usegit flag
                Moving towards using `cordova platform add git-url#my-branch` instead.
Background:
http://apache.markmail.org/message/7cf5zovxcgdxgwa2?q=ommenjik+list:org%2Eapache%2Eincubator%2Ecallback-dev+order:date-backward&page=1#query:ommenjik%20list%3Aorg.apache.incubator.callback-dev%20order%3Adate-backward+page:1+mid:c3cep6d3eez5kefe+state:results