### PR TITLE
CB-5578 Adds `clean` command to cordova-cli

### DIFF
--- a/doc/clean.txt
+++ b/doc/clean.txt
@@ -1,0 +1,8 @@
+Synopsis
+
+    cordova clean [PLATFORM..]
+
+Cleans the build artifacts for the specified platform, or all platforms
+by running platform-provided clean script.
+
+To provide platform specific options, you must include them after `--`.

--- a/doc/cordova.txt
+++ b/doc/cordova.txt
@@ -18,6 +18,7 @@ Project Commands
 
     prepare ............................ Copy files into platform(s) for building
     compile ............................ Build platform(s)
+    clean .............................. Cleanup project from build artifacts
 
     run ................................ Run project
                                             (including prepare && compile)

--- a/src/cli.js
+++ b/src/cli.js
@@ -186,7 +186,7 @@ function cli(inputArgs) {
     };
 
 
-    if (cmd == 'emulate' || cmd == 'build' || cmd == 'prepare' || cmd == 'compile' || cmd == 'run') {
+    if (cmd == 'emulate' || cmd == 'build' || cmd == 'prepare' || cmd == 'compile' || cmd == 'run' || cmd === 'clean') {
         // All options without dashes are assumed to be platform names
         opts.platforms = undashed.slice(1);
         var badPlatforms = _.difference(opts.platforms, known_platforms);


### PR DESCRIPTION
This is an implementation for [CB-5578](https://issues.apache.org/jira/browse/CB-5578). Requires https://github.com/apache/cordova-lib/pull/241 to be merged first.