### PR TITLE
CB-9784 Remove CLI logger levels prefixes

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -130,12 +130,8 @@ function cli(inputArgs) {
 
     // For CordovaError print only the message without stack trace unless we
     // are in a verbose mode.
-    process.on('uncaughtException', function(err){
-        if ( (err instanceof CordovaError) && !args.verbose ) {
-            events.emit('error', err.message);
-        } else {
-            events.emit('error', err.stack);
-        }
+    process.on('uncaughtException', function(err) {
+        logger.error(err);
         process.exit(1);
     });
 
@@ -143,7 +139,6 @@ function cli(inputArgs) {
     events.on('log', logger.normal);
     events.on('info', logger.info);
     events.on('warn', logger.warn);
-    events.on('error', logger.error);
 
     // Set up event handlers for logging and results emitted as events.
     events.on('results', logger.results);

--- a/src/logger.js
+++ b/src/logger.js
@@ -51,6 +51,11 @@ function formatError(error, isVerbose) {
         message = error;
     }
 
+    if(message.toUpperCase().indexOf('ERROR:') !== 0) {
+        // Needed for backward compatibility with external tools
+        message = 'Error: ' + message;
+    }
+
     return message;
 }
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -27,7 +27,6 @@ var EOL = require('os').EOL;
 
 var logger = {
     levels: {},
-    prefixes: {},
     colors: {},
     output: process.stdout
 };
@@ -59,13 +58,12 @@ function formatError(error, isVerbose) {
 logger.log = function (logLevel, message) {
     if (this.levels[logLevel] >= this.levels[this.logLevel]) {
         var isVerbose = this.logLevel === 'verbose';
-        var prefix = this.prefixes[logLevel] ? this.prefixes[logLevel] + ': ' : '';
 
         if(message instanceof Error) {
             message = formatError(message, isVerbose);
         }
 
-        message = prefix + message + EOL;
+        message = message + EOL;
 
         if (!this.cursor) {
             this.output.write(message);
@@ -80,9 +78,8 @@ logger.log = function (logLevel, message) {
     }
 };
 
-logger.addLevel = function (level, severity, prefix, color) {
+logger.addLevel = function (level, severity, color) {
     this.levels[level] = severity;
-    prefix && (this.prefixes[level] = prefix);
     color && (this.colors[level] = color);
 
     if (!this[level]) {
@@ -97,11 +94,11 @@ logger.setLevel = function (logLevel) {
     }
 };
 
-logger.addLevel('verbose', 1000, 'VERB ', 'grey');
-logger.addLevel('normal' , 2000, 'LOG  ');
-logger.addLevel('warn'   , 2000, 'WARN ', 'yellow');
-logger.addLevel('info'   , 3000, 'INFO ', 'blue');
-logger.addLevel('error'  , 5000, 'ERROR', 'red');
+logger.addLevel('verbose', 1000, 'grey');
+logger.addLevel('normal' , 2000);
+logger.addLevel('warn'   , 2000, 'yellow');
+logger.addLevel('info'   , 3000, 'blue');
+logger.addLevel('error'  , 5000, 'red');
 logger.addLevel('results' , 10000);
 
 logger.setLevel('normal');


### PR DESCRIPTION
`EventEmitter` usage provides info on an event level so the prefixing may be superfluous taking into account we have coloring distinction for event levels.

The change is proposed by @TimBarham.

[Jira issue](https://issues.apache.org/jira/browse/CB-9784)