### PR TITLE
Cb 9964

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -97,6 +97,7 @@ function cli(inputArgs) {
         , 'nobuild': Boolean
         , 'list': Boolean
         , 'buildConfig' : String
+        , 'template' : String
         };
 
     var shortHands =
@@ -104,6 +105,7 @@ function cli(inputArgs) {
         , 'v' : '--version'
         , 'h' : '--help'
         , 'src' : '--copy-from'
+        , 't' : '--template'
         };
 
     // If no inputArgs given, use process.argv.

--- a/src/cli.js
+++ b/src/cli.js
@@ -334,7 +334,7 @@ function cli(inputArgs) {
         customWww = args['copy-from'] || args['link-to'] || args.template;
 
         if (customWww) {
-            if (!args.template && customWww.indexOf('http') === 0) {
+            if (args['link-to'] && customWww.indexOf('http') === 0) {
                 throw new CordovaError(
                     'Only local paths for custom www assets are supported.'
                 );
@@ -351,7 +351,7 @@ function cli(inputArgs) {
 
             if (args['link-to'])
                 wwwCfg.link = true;
-            else if (args.template)
+            else
                 wwwCfg.template = true;
 
             cfg.lib = cfg.lib || {};

--- a/src/cli.js
+++ b/src/cli.js
@@ -289,35 +289,7 @@ function cli(inputArgs) {
         var port = undashed[1];
         cordova.raw.serve(port).done();
     } else if (cmd == 'create') {
-        var cfg = {};
-        // If we got a fourth parameter, consider it to be JSON to init the config.
-        if ( undashed[4] ) {
-            cfg = JSON.parse(undashed[4]);
-        }
-        var customWww = args['copy-from'] || args['link-to'];
-        if (customWww) {
-            if (customWww.indexOf('http') === 0) {
-                throw new CordovaError(
-                    'Only local paths for custom www assets are supported.'
-                );
-            }
-            if ( customWww.substr(0,1) === '~' ) {  // resolve tilde in a naive way.
-                customWww = path.join(process.env.HOME,  customWww.substr(1));
-            }
-            customWww = path.resolve(customWww);
-            var wwwCfg = { url: customWww };
-            if (args['link-to']) {
-                wwwCfg.link = true;
-            }
-            cfg.lib = cfg.lib || {};
-            cfg.lib.www = wwwCfg;
-        }
-        // create(dir, id, name, cfg)
-        cordova.raw.create( undashed[1]  // dir to create the project in
-                          , undashed[2]  // App id
-                          , undashed[3]  // App name
-                          , cfg
-        ).done();
+        create();
     } else {
         // platform/plugins add/rm [target(s)]
         subcommand = undashed[1]; // sub-command like "add", "ls", "rm" etc.
@@ -344,5 +316,51 @@ function cli(inputArgs) {
                             , shrinkwrap: args.shrinkwrap || false
                             };
         cordova.raw[cmd](subcommand, targets, download_opts).done();
+    }
+
+    function create() {
+        var cfg;            // Create config
+        var customWww;      // Template path
+        var wwwCfg;         // Template config
+
+        // If we got a fourth parameter, consider it to be JSON to init the config.
+        if (undashed[4])
+            cfg = JSON.parse(undashed[4]);
+        else
+            cfg = {};
+
+        customWww = args['copy-from'] || args['link-to'] || args.template;
+
+        if (customWww) {
+            if (!args.template && customWww.indexOf('http') === 0) {
+                throw new CordovaError(
+                    'Only local paths for custom www assets are supported.'
+                );
+            }
+
+            // Resolve tilda
+            if (customWww.substr(0,1) === '~')
+                customWww = path.join(process.env.HOME,  customWww.substr(1));
+
+            wwwCfg = {
+                url: customWww,
+                template: false
+            };
+
+            if (args['link-to'])
+                wwwCfg.link = true;
+            else if (args.template)
+                wwwCfg.template = true;
+
+            cfg.lib = cfg.lib || {};
+            cfg.lib.www = wwwCfg;
+        }
+
+        // create(dir, id, name, cfg)
+        cordova.raw.create( undashed[1]  // dir to create the project in
+            , undashed[2]  // App id
+            , undashed[3]  // App name
+            , cfg
+        ).done();
     }
 }


### PR DESCRIPTION
When providing a --template argument during project creation, users can use templates apps from a local directory, GitHub, or NPM. This makes sharing templates, and example apps much easier.

When using a GitHub URL, the user may specific a branch to pull from by appending a "#" followed by a tag name to the Git URL.

A version can also be supplied by the user when fetching a template from NPM. This may be done by appending a "@" followed by the NPM version to the NPM package name. 
