### PR TITLE
Remove invalid space from license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,5 +142,5 @@
       "email":"purplecabbage@gmail.com"
     }
   ],
-  "license": " Apache-2.0"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Typo introduced in e2f3cf6d403a9f23fa130ddfdc5fc74c69365f6e

Ping @nikhilkh