### PR TITLE
CB-10062 Error: EACCES: permission denied - update-notifier-cordova.json

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -60,13 +60,23 @@ function init() {
 }
 
 function checkForUpdates() {
-    // Checks for available update and returns an instance
-    var notifier = updateNotifier({
-        pkg: pkg
-    });
+    try {
+        // Checks for available update and returns an instance
+        var notifier = updateNotifier({
+            pkg: pkg
+        });
 
-    // Notify using the built-in convenience method
-    notifier.notify();
+        // Notify using the built-in convenience method
+        notifier.notify();
+    } catch (e) {
+        // https://issues.apache.org/jira/browse/CB-10062
+        if (e && e.message && /EACCES/.test(e.message)) {
+            console.log('Update notifier was not able to access the config file.\n' +
+                'You may grant permissions to the file: \'sudo chmod 744 ~/.config/configstore/update-notifier-cordova.json\'');
+        } else {
+            throw e;
+        }
+    }
 }
 
 module.exports = cli;


### PR DESCRIPTION
Catch permissions error and print a workaround

[Jira issue](https://issues.apache.org/jira/browse/CB-10062)