### PR TITLE
CB-11042: Add cordova run option to skip prepare

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -464,29 +464,31 @@ cordova build [<platform> [...]]
 
 ### Synopsis
 
-Prepares, builds (unless `--nobuild` is specified) and deploys app on specified platform devices/emulators. If a device is connected it will be used, unless an eligible emulator is already running.
+Prepares, builds, and deploys app on specified platform devices/emulators. If a device is connected it will be used, unless an eligible emulator is already running.
 
 ###Syntax
 
 ```bash
 cordova run [<platform> [...]]
-    [--list | --nobuild ]
+    [--list | --debug | --release]
+    [--noprepare] [--nobuild]
     [--device|--emulator|--target=<targetName>]
     [--buildConfig=<configfile>]
     [--browserify]
     [-- <platformOpts>]
 ```
 
-| Option     | Description
-|------------|------------------
+| Option      | Description
+|-------------|------------------
 | `<platform> [..]` | Platform name(s) to run. If not specified, all platforms are run.
-|--nobuild   | Skip building
-|--debug     | Deploy a debug build. This is the default behavior unless `--release` is specified.
-|--release   | Deploy a release build
-|--device    | Deploy to a device
-|--emulator  | Deploy to an emulator
-|--target    | Deploy to a specific target emulator/device. Use `--list` to display target options
-| --list     | Lists available targets. Displays both device and emulator deployment targets unless specified
+| --list      | Lists available targets. Displays both device and emulator deployment targets unless specified
+| --debug     | Deploy a debug build. This is the default behavior unless `--release` is specified.
+| --release   | Deploy a release build
+| --noprepare | Skip preparing
+| --nobuild   | Skip building
+| --device    | Deploy to a device
+| --emulator  | Deploy to an emulator
+| --target    | Deploy to a specific target emulator/device. Use `--list` to display target options
 | --buildConfig=`<configFile>` | Default: build.json in cordova root directory. <br/> Use the specified build configuration file. `build.json` file is used to specify paramaters to customize the app build process esecially related to signing the package.
 | --browserify | Compile plugin JS at build time using browserify instead of runtime
 | `<platformOpts>` | To provide platform specific options, you must include them after `--` separator. Review platform guide docs for more details.

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -484,7 +484,7 @@ cordova run [<platform> [...]]
 | --list      | Lists available targets. Displays both device and emulator deployment targets unless specified
 | --debug     | Deploy a debug build. This is the default behavior unless `--release` is specified.
 | --release   | Deploy a release build
-| --noprepare | Skip preparing
+| --noprepare | Skip preparing (available in Cordova v6.2 or later)
 | --nobuild   | Skip building
 | --device    | Deploy to a device
 | --emulator  | Deploy to an emulator

--- a/doc/run.txt
+++ b/doc/run.txt
@@ -1,9 +1,9 @@
 Synopsis
 
-    cordova-cli run [MODE] [PROD] [TARGET] [PLATS] [BUILDCONFIG] [-- POPTS] 
+    cordova-cli run [MODE] [BUILDOPTS] [TARGET] [PLATS] [BUILDCONFIG] [-- POPTS]
 
-      MODE:       --list|--nobuild
-      PROD:        --debug|--release
+      MODE:        --list|--debug|--release
+      BUILDOPTS:   --noprepare --nobuild
       TARGET:      DEVICECLASS|--target=FOO
       PLATS:       PLATFORM [...]
       BUILDCONFIG: --buildConfig=CONFIGFILE
@@ -12,33 +12,34 @@ Synopsis
 
 Deploys app on specified platform devices / emulators
 
-    --nobuild .......................... don't build
+    --list ............................. Lists available targets
+                                         Will display both device and emulator
+                                         unless DEVICECLASS option is provided
 
     --debug ............................ Deploy a debug build
     --release .......................... Deploy a release build
+
+    --noprepare ........................ Don't prepare
+    --nobuild .......................... Don't build
 
     --device ........................... Deploy to a device
     --emulator ......................... Deploy to an emulator
     --target ........................... Deploy to a specific target
 
-    --list ............................. Lists available targets
-                                         Will display both device and emulator
-                                         unless DEVICECLASS option is provided
-
     --buildConfig....................... Use the specified build configuration
                                          instead of default build.json
 
-    --browserify ....................... Compile plugin JS at build time using 
+    --browserify ....................... Compile plugin JS at build time using
                                          browserify instead of runtime.
 
 To provide platform specific options, you must include them after `--`.
 
 Technical details
-    calls cordova prepare
+    calls cordova prepare (unless --noprepare)
     calls PLATFORM run
         PLATFORM run calls PLATFORM build (unless --nobuild)
 
-Examples 
+Examples
     cordova-cli run android --release --buildConfig=..\myBuildConfig.json --target=myEmulator
     cordova-cli run android --nobuild
     cordova-cli run ios --device

--- a/src/cli.js
+++ b/src/cli.js
@@ -105,6 +105,7 @@ function cli(inputArgs) {
         , 'emulator': Boolean
         , 'target' : String
         , 'browserify': Boolean
+        , 'noprepare': Boolean
         , 'nobuild': Boolean
         , 'list': Boolean
         , 'buildConfig' : String


### PR DESCRIPTION
Parse and document a --noprepare option for the cordova run command.

See https://github.com/apache/cordova-lib/pull/426 for the corresponding cordova-lib change that skips the prepare step if the noprepare option is specified.