### PR TITLE
CB-11250 Fix CLI tests verifying the version

### DIFF
--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -52,17 +52,17 @@ describe("cordova cli", function () {
 
             it("will spit out the version with -v", function () {
                 cli(["node", "cordova", "-v"]);
-                expect(console.log.mostRecentCall.args[0]).toMatch(version);
+                expect(console.log.mostRecentCall.args[0]).toContain(version);
             });
 
             it("will spit out the version with --version", function () {
                 cli(["node", "cordova", "--version"]);
-                expect(console.log.mostRecentCall.args[0]).toMatch(version);
+                expect(console.log.mostRecentCall.args[0]).toContain(version);
             });
 
             it("will spit out the version with -v anywhere", function () {
                 cli(["node", "cordova", "one", "-v", "three"]);
-                expect(console.log.mostRecentCall.args[0]).toMatch(version);
+                expect(console.log.mostRecentCall.args[0]).toContain(version);
             });
         });
     });


### PR DESCRIPTION
[Jira issue](https://issues.apache.org/jira/browse/CB-11250)

`toMatch` expects regexp and the version can contain special symbols so using a check for substring.