### PR TITLE
CB-11976 - Add deprecated node version warning for 0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ node_js:
   - "0.12"
   - "4"
   - "6"
+  
+before_install:
+    - npm cache clean -f
 
 # getting cordova tools dependencies from github
 # to make sure we're using their latest versions

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
     "description": "Cordova command line interface tool",
     "main": "cordova",
     "engines": {
-        "node": ">=0.9.9"
+        "node": ">=4.0.0"
     },
-    "engineStrict": true,
     "bin": {
         "cordova": "./bin/cordova"
     },

--- a/src/cli.js
+++ b/src/cli.js
@@ -287,6 +287,12 @@ function cli(inputArgs) {
         }
     }
 
+    if (/^v0.\d+[.\d+]*/.exec(process.version)) { // matches v0.* 
+        var msg = 'Warning: using node version ' + process.version +
+                ' which has been deprecated. Please upgrade to the latest node version available (v6.x is recommended).';
+        logger.warn(msg);
+    }
+
     // If there were arguments protected from nopt with a double dash, keep
     // them in unparsedArgs. For example:
     // cordova build ios -- --verbose --whatever


### PR DESCRIPTION
### Platforms affected

All.

### What does this PR do?

Before running each command, it will check if the node version is 0.x. If it is, it prints out a warning.

### What testing has been done on this change?

Tested locally.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.

