### PR TITLE
CB-12018 : updated tests to function with jasmine instead of jasmine-node

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,0 +1,24 @@
+{
+    "disallowMixedSpacesAndTabs": true,
+    "disallowTrailingWhitespace": true,
+    "validateLineBreaks": "LF",
+    "validateIndentation": 4,
+    "requireLineFeedAtFileEnd": true,
+
+    "disallowSpaceAfterPrefixUnaryOperators": true,
+    "disallowSpaceBeforePostfixUnaryOperators": true,
+    "requireSpaceAfterLineComment": true,
+    "requireCapitalizedConstructors": true,
+
+    "disallowSpacesInNamedFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+
+    "requireSpaceAfterKeywords": [
+      "if",
+      "else",
+      "for",
+      "while",
+      "do"
+    ]
+}

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,4 @@
+spec-cordova/fixtures/*
+spec-plugman/projects/*
+spec-plugman/plugins/*
+spec-cordova/temp/*

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "cordova": "./bin/cordova"
   },
   "scripts": {
-    "test": "jasmine --captureExceptions --color",
-    "cover": "jasmine"
+    "test": "npm run jshint && npm run jasmine",
+    "jshint": "jshint spec && jshint src",
+    "cover": "istanbul cover --root src --print detail jasmine",
+    "jasmine": "jasmine --captureExceptions --color"
   },
   "repository": {
     "type": "git",
@@ -38,7 +40,8 @@
   },
   "devDependencies": {
     "jasmine": "^2.5.2",
-    "istanbul": "^0.4.5"
+    "istanbul": "^0.4.5",
+    "jshint": "^2.9.4"
   },
   "author": "Anis Kadri",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "cordova": "./bin/cordova"
   },
   "scripts": {
-    "test": "node node_modules/jasmine-node/bin/jasmine-node --captureExceptions --color spec",
-    "cover": "node node_modules/istanbul/lib/cli.js cover --root src --print detail node_modules/jasmine-node/bin/jasmine-node -- spec"
+    "test": "jasmine --captureExceptions --color",
+    "cover": "jasmine"
   },
   "repository": {
     "type": "git",
@@ -37,8 +37,8 @@
     "update-notifier": "^0.5.0"
   },
   "devDependencies": {
-    "istanbul": "^0.4.5",
-    "jasmine-node": "1.14.5"
+    "jasmine": "^2.5.2",
+    "istanbul": "^0.4.5"
   },
   "author": "Anis Kadri",
   "contributors": [

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -41,7 +41,7 @@ describe("cordova cli", function () {
             return new FakeEvents();
         };
 
-        spyOn(events, "on").andReturn(new FakeEvents());
+        spyOn(events, "on").and.returnValue(new FakeEvents());
 
         // Spy and mute output
         spyOn(logger, 'results');
@@ -55,76 +55,76 @@ describe("cordova cli", function () {
     });
 
     describe("options", function () {
-        describe("version", function () {
-            var version = require("../package").version;
+      describe("version", function () {
+        var version = require("../package").version;
 
-            beforeEach(function () {
-            });
-            
-            it("will spit out the version with -v", function (done) {
-                cli(["node", "cordova", "-v"], function() {
-                    expect(logger.results.mostRecentCall.args[0]).toMatch(version);
-                    done();
-                });
-            });
-
-            it("will spit out the version with --version", function (done) {
-                cli(["node", "cordova", "--version"], function () {
-                    expect(logger.results.mostRecentCall.args[0]).toMatch(version);
-                    done()
-                });
-            });
-
-            it("will spit out the version with -v anywhere", function (done) {
-                cli(["node", "cordova", "one", "-v", "three"], function () {
-                    expect(logger.results.mostRecentCall.args[0]).toMatch(version);
-                    done();
-                });
-            });
+        beforeEach(function () {
         });
+        
+        it("Test#001 : will spit out the version with -v", function (done) {
+          cli(["node", "cordova", "-v"], function() {
+            expect(logger.results.calls.mostRecent().args[0]).toMatch(version);
+            done();
+          });
+        }, 60000);
+
+        it("Test#002 : will spit out the version with --version", function (done) {  
+          cli(["node", "cordova", "--version"], function () {
+            expect(logger.results.calls.mostRecent().args[0]).toMatch(version);
+            done()
+          }, 60000);
+        });
+
+        it("Test#003 : will spit out the version with -v anywhere", function (done) {
+          cli(["node", "cordova", "one", "-v", "three"], function () {
+            expect(logger.results.calls.mostRecent().args[0]).toMatch(version);
+            done();
+          });
+        }, 60000);
+      });
     });
 
-    describe("project commands other than plugin and platform", function () {
+    describe("Test#004 : project commands other than plugin and platform", function () {
         beforeEach(function () {
-            spyOn(cordova.raw, "build").andReturn(Q());
+            spyOn(cordova.raw, "build").and.returnValue(Q());
         });
 
-        it("will call command with all arguments passed through", function (done) {
+        it("Test#005 : will call command with all arguments passed through", function (done) {
             cli(["node", "cordova", "build", "blackberry10", "--", "-k", "abcd1234"], function () {
                 expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { argv: ['-k', 'abcd1234'] }, verbose: false, silent: false, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
                 done();
             });
-        });
+        }, 60000);
 
-        it("will consume the first instance of -d", function (done) {
+        it("Test#006 : will consume the first instance of -d", function (done) {
             cli(["node", "cordova", "-d", "build", "blackberry10", "--", "-k", "abcd1234", "-d"], function () {
                 expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '-d'] }, verbose: true, silent: false, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
                 done();
             });
         });
 
-        it("will consume the first instance of --verbose", function (done) {
+        it("Test#007 : will consume the first instance of --verbose", function (done) {
             cli(["node", "cordova", "--verbose", "build", "blackberry10", "--", "-k", "abcd1234", "--verbose"], function () {
                 expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '--verbose'] }, verbose: true, silent: false, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
                 done();
             });
         });
 
-        it("will consume the first instance of either --verbose or -d", function (done) {
+        it("Test#008 : will consume the first instance of either --verbose or -d", function (done) {
             cli(["node", "cordova", "--verbose", "build", "blackberry10", "--", "-k", "abcd1234", "-d"], function () {
                 expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '-d'] }, verbose: true, silent: false, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
                 done();
             });
         });
 
-        it("will consume the first instance of either --verbose or -d", function (done) {
+        it("Test#009 : will consume the first instance of either --verbose or -d", function (done) {
             cli(["node", "cordova", "-d", "build", "blackberry10", "--", "-k", "abcd1234", "--verbose"], function () {
                 expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '--verbose'] }, verbose: true, silent: false, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
                 done();
             });
         });
 
-        it("will consume the first instance of --silent", function (done) {
+        it("Test#010 : will consume the first instance of --silent", function (done) {
             cli(["node", "cordova", "--silent", "build", "blackberry10", "--", "-k", "abcd1234", "--silent"], function () {
                 expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { silent: true, argv: ['-k', 'abcd1234', '--silent'] }, verbose: false, silent: true, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
                 done();
@@ -134,11 +134,11 @@ describe("cordova cli", function () {
 
     describe("create", function () {
         beforeEach(function () {
-            spyOn(cordova.raw, "create").andReturn(Q());
-            spyOn(cordova_lib, "CordovaError");
+            spyOn(cordova.raw, "create").and.returnValue(Q());
+            // spyOn(cordova_lib, "CordovaError");
         });
 
-        it("calls cordova raw create", function (done) {
+        it("Test#011 : calls cordova raw create", function (done) {
             cli(["node", "cordova", "create", "a", "b", "c", "--link-to", "c:\\personalWWW"], function () {
                 expect(cordova.raw.create).toHaveBeenCalledWith("a", "b", "c", jasmine.any(Object), jasmine.any(Object));
                 done();
@@ -148,43 +148,43 @@ describe("cordova cli", function () {
 
     describe("plugin", function () {
         beforeEach(function () {
-            spyOn(cordova.raw, "plugin").andReturn(Q());
+            spyOn(cordova.raw, "plugin").and.returnValue(Q());
         });
 
-        it("will pass variables", function (done) {
+        it("Test#012 : will pass variables", function (done) {
             cli(["node", "cordova", "plugin", "add", "facebook", "--variable", "FOO=foo"], function () {
                 expect(cordova.raw.plugin).toHaveBeenCalledWith(
                     "add",
                     ["facebook"],
                     jasmine.any(Object)
                 );
-                var opts = cordova.raw.plugin.calls[0].args[2];
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
                 expect(opts.cli_variables.FOO).toBe('foo');
                 done();
             });
         });
 
-        it("will  support variables with =", function (done) {
+        it("Test#013 : will  support variables with =", function (done) {
             cli(["node", "cordova", "plugin", "add", "facebook", "--variable", "MOTO=DELTA=WAS=HERE"], function () {
                 expect(cordova.raw.plugin).toHaveBeenCalledWith(
                     "add",
                     ["facebook"],
                     jasmine.any(Object)
                 );
-                var opts = cordova.raw.plugin.calls[0].args[2];
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
                 expect(opts.cli_variables.MOTO).toBe('DELTA=WAS=HERE');
                 done();
             });
         });
 
-        it("will pass hook patterns to suppress", function (done) {
+        it("Test#014 : will pass hook patterns to suppress", function (done) {
             cli(["node", "cordova", "plugin", "add", "facebook", "--nohooks", "before_plugin_add"], function () {
                 expect(cordova.raw.plugin).toHaveBeenCalledWith(
                     "add",
                     ["facebook"],
                     jasmine.any(Object)
                 );
-                var opts = cordova.raw.plugin.calls[0].args[2];
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
                 expect(opts.nohooks[0]).toBe("before_plugin_add");
                 done();
             });
@@ -193,9 +193,9 @@ describe("cordova cli", function () {
     });
     
     describe("telemetry", function() {
-       it("skips prompt when user runs 'cordova telemetry X'", function(done) {
+       it("Test#015 : skips prompt when user runs 'cordova telemetry X'", function(done) {
            var wasPromptShown = false;
-           spyOn(telemetry, "showPrompt").andCallFake(function () {
+           spyOn(telemetry, "showPrompt").and.callFake(function () {
                wasPromptShown = true;
            });
 
@@ -207,9 +207,9 @@ describe("cordova cli", function () {
            });         
        });
        
-       it("is NOT collected when user runs 'cordova telemetry on' while NOT opted-in", function(done) {
-           spyOn(telemetry, "isOptedIn").andReturn(false);
-           spyOn(telemetry, "isCI").andReturn(false);
+       it("Test#016 : is NOT collected when user runs 'cordova telemetry on' while NOT opted-in", function(done) {
+           spyOn(telemetry, "isOptedIn").and.returnValue(false);
+           spyOn(telemetry, "isCI").and.returnValue(false);
            
            spyOn(telemetry, "track");
            
@@ -219,9 +219,9 @@ describe("cordova cli", function () {
            });
        });
        
-       it("is collected when user runs 'cordova telemetry off' while opted-in", function(done) {
-           spyOn(telemetry, "isOptedIn").andReturn(true);
-           spyOn(telemetry, "isCI").andReturn(false);
+       it("Test#017 : is collected when user runs 'cordova telemetry off' while opted-in", function(done) {
+           spyOn(telemetry, "isOptedIn").and.returnValue(true);
+           spyOn(telemetry, "isCI").and.returnValue(false);
            
            spyOn(telemetry, "track");
            
@@ -231,11 +231,11 @@ describe("cordova cli", function () {
            });
        });
        
-       it("tracks platforms/plugins subcommands", function(done) {
-           spyOn(telemetry, "isOptedIn").andReturn(true);
-           spyOn(telemetry, "isCI").andReturn(false);
-           spyOn(telemetry, "hasUserOptedInOrOut").andReturn(true);
-           spyOn(cordova.raw, "platform").andReturn(Q());
+       it("Test#018 : tracks platforms/plugins subcommands", function(done) {
+           spyOn(telemetry, "isOptedIn").and.returnValue(true);
+           spyOn(telemetry, "isCI").and.returnValue(false);
+           spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
+           spyOn(cordova.raw, "platform").and.returnValue(Q());
            
            spyOn(telemetry, "track");
            
@@ -245,13 +245,13 @@ describe("cordova cli", function () {
            });
        });
        
-       it("shows prompt if user neither opted in or out yet", function(done) {
-           spyOn(cordova.raw, "prepare").andReturn(Q());
-           spyOn(telemetry, "hasUserOptedInOrOut").andReturn(false);
+       it("Test#019 : shows prompt if user neither opted in or out yet", function(done) {
+           spyOn(cordova.raw, "prepare").and.returnValue(Q());
+           spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(false);
            
-           spyOn(telemetry, "isCI").andReturn(false);
-           spyOn(telemetry, "isNoTelemetryFlag").andReturn(false);
-           spyOn(telemetry, "showPrompt").andReturn(Q(false));
+           spyOn(telemetry, "isCI").and.returnValue(false);
+           spyOn(telemetry, "isNoTelemetryFlag").and.returnValue(false);
+           spyOn(telemetry, "showPrompt").and.returnValue(Q(false));
            
            cli(["node", "cordova", "prepare"], function () {
                expect(telemetry.showPrompt).toHaveBeenCalled();
@@ -261,12 +261,12 @@ describe("cordova cli", function () {
 
        // ToDO: Figure out a way to modify default timeout
        // ... Timeout overriding isn't working anymore due to a bug with jasmine-node
-       xit("opts-out if prompt times out AND it tracks opt-out", function(done) {
+       xit("Test#020 : opts-out if prompt times out AND it tracks opt-out", function(done) {
            // Remove any optOut settings that might have been saved
            // ... and force prompt to be shown
            telemetry.clear();
-           spyOn(telemetry, "hasUserOptedInOrOut").andReturn(false);
-           spyOn(telemetry, "isCI").andReturn(false);
+           spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(false);
+           spyOn(telemetry, "isCI").and.returnValue(false);
            spyOn(telemetry, "track");
            
            cli(["node", "cordova", "--version"], function () {
@@ -276,10 +276,10 @@ describe("cordova cli", function () {
            });
        }/*, 45000*/);
        
-       it("is NOT collected in CI environments and doesn't prompt", function(done) {
-           spyOn(telemetry, "hasUserOptedInOrOut").andReturn(true);
-           spyOn(telemetry, "isOptedIn").andReturn(true);
-           spyOn(telemetry, "isCI").andReturn(true);
+       it("Test#021 : is NOT collected in CI environments and doesn't prompt", function(done) {
+           spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
+           spyOn(telemetry, "isOptedIn").and.returnValue(true);
+           spyOn(telemetry, "isCI").and.returnValue(true);
            
            spyOn(telemetry, "showPrompt");
            spyOn(telemetry, "track");
@@ -291,10 +291,10 @@ describe("cordova cli", function () {
            });
        });
        
-       it("is NOT collected when --no-telemetry flag found and doesn't prompt", function(done) {
-           spyOn(telemetry, "hasUserOptedInOrOut").andReturn(false);
-           spyOn(telemetry, "isOptedIn").andReturn(true);
-           spyOn(telemetry, "isCI").andReturn(false);
+       it("Test#022 : is NOT collected when --no-telemetry flag found and doesn't prompt", function(done) {
+           spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(false);
+           spyOn(telemetry, "isOptedIn").and.returnValue(true);
+           spyOn(telemetry, "isCI").and.returnValue(false);
            
            spyOn(telemetry, "showPrompt");
            spyOn(telemetry, "track");
@@ -306,10 +306,10 @@ describe("cordova cli", function () {
            });
        });
        
-       it("is NOT collected if user opted out", function(done) {
-           spyOn(telemetry, "hasUserOptedInOrOut").andReturn(true);
-           spyOn(telemetry, "isOptedIn").andReturn(false);
-           spyOn(telemetry, "isCI").andReturn(false);
+       it("Test#023 : is NOT collected if user opted out", function(done) {
+           spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
+           spyOn(telemetry, "isOptedIn").and.returnValue(false);
+           spyOn(telemetry, "isCI").and.returnValue(false);
            
            spyOn(telemetry, "showPrompt");
            spyOn(telemetry, "track");
@@ -321,10 +321,10 @@ describe("cordova cli", function () {
            });
        });
        
-       it("is collected if user opted in", function(done) {
-           spyOn(telemetry, "hasUserOptedInOrOut").andReturn(true);
-           spyOn(telemetry, "isOptedIn").andReturn(true);
-           spyOn(telemetry, "isCI").andReturn(false);
+       it("Test#024 : is collected if user opted in", function(done) {
+           spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
+           spyOn(telemetry, "isOptedIn").and.returnValue(true);
+           spyOn(telemetry, "isCI").and.returnValue(false);
            
            spyOn(telemetry, "showPrompt");
            spyOn(telemetry, "track");
@@ -336,10 +336,10 @@ describe("cordova cli", function () {
            });
        });
        
-       it("track opt-out that happened via 'cordova telemetry off' even if user is NOT opted-in ", function(done) {
-           spyOn(telemetry, "isCI").andReturn(false);
-           spyOn(telemetry, "isOptedIn").andReturn(false); // same as calling `telemetry.turnOff();`
-           spyOn(telemetry, "hasUserOptedInOrOut").andReturn(true);
+       it("Test#025 : track opt-out that happened via 'cordova telemetry off' even if user is NOT opted-in ", function(done) {
+           spyOn(telemetry, "isCI").and.returnValue(false);
+           spyOn(telemetry, "isOptedIn").and.returnValue(false); // same as calling `telemetry.turnOff();`
+           spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
            spyOn(telemetry, "track");
 
            expect(telemetry.isOptedIn()).toBeFalsy();

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -55,33 +55,30 @@ describe("cordova cli", function () {
     });
 
     describe("options", function () {
-      describe("version", function () {
-        var version = require("../package").version;
-
-        beforeEach(function () {
-        });
+        describe("version", function () {
+            var version = require("../package").version;
         
-        it("Test#001 : will spit out the version with -v", function (done) {
-          cli(["node", "cordova", "-v"], function() {
-            expect(logger.results.calls.mostRecent().args[0]).toMatch(version);
-            done();
-          });
-        }, 60000);
+            it("Test#001 : will spit out the version with -v", function (done) {
+              cli(["node", "cordova", "-v"], function() {
+                expect(logger.results.calls.mostRecent().args[0]).toMatch(version);
+                done();
+              });
+            }, 60000);
 
-        it("Test#002 : will spit out the version with --version", function (done) {  
-          cli(["node", "cordova", "--version"], function () {
-            expect(logger.results.calls.mostRecent().args[0]).toMatch(version);
-            done()
-          }, 60000);
+            it("Test#002 : will spit out the version with --version", function (done) {  
+              cli(["node", "cordova", "--version"], function () {
+                expect(logger.results.calls.mostRecent().args[0]).toMatch(version);
+                done()
+              }, 60000);
+            });
+
+            it("Test#003 : will spit out the version with -v anywhere", function (done) {
+              cli(["node", "cordova", "one", "-v", "three"], function () {
+                expect(logger.results.calls.mostRecent().args[0]).toMatch(version);
+                done();
+              });
+            }, 60000);
         });
-
-        it("Test#003 : will spit out the version with -v anywhere", function (done) {
-          cli(["node", "cordova", "one", "-v", "three"], function () {
-            expect(logger.results.calls.mostRecent().args[0]).toMatch(version);
-            done();
-          });
-        }, 60000);
-      });
     });
 
     describe("Test#004 : project commands other than plugin and platform", function () {
@@ -131,11 +128,11 @@ describe("cordova cli", function () {
             });
         });
     });
-
+    
     describe("create", function () {
         beforeEach(function () {
             spyOn(cordova.raw, "create").and.returnValue(Q());
-            // spyOn(cordova_lib, "CordovaError");
+            spyOn(cordova_lib, "CordovaError");
         });
 
         it("Test#011 : calls cordova raw create", function (done) {

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -68,7 +68,7 @@ describe("cordova cli", function () {
             it("Test#002 : will spit out the version with --version", function (done) {  
               cli(["node", "cordova", "--version"], function () {
                 expect(logger.results.calls.mostRecent().args[0]).toMatch(version);
-                done()
+                done();
               }, 60000);
             });
 
@@ -132,7 +132,6 @@ describe("cordova cli", function () {
     describe("create", function () {
         beforeEach(function () {
             spyOn(cordova.raw, "create").and.returnValue(Q());
-            spyOn(cordova_lib, "CordovaError");
         });
 
         it("Test#011 : calls cordova raw create", function (done) {

--- a/spec/create.spec.js
+++ b/spec/create.spec.js
@@ -38,7 +38,7 @@ describe("cordova cli", function () {
 
         describe("parseConfig", function() { 
 
-            it("should be defined", function () {
+            it("Test#001 : should be defined", function () {
                 expect(clicreate.parseConfig).toEqual(jasmine.any(Function));    
             });
 
@@ -46,7 +46,7 @@ describe("cordova cli", function () {
 
         describe("create", function() { 
 
-            it("should be defined", function () {
+            it("Test#002 : should be defined", function () {
                 expect(clicreate.run).toEqual(jasmine.any(Function));    
             });
 

--- a/spec/help.spec.js
+++ b/spec/help.spec.js
@@ -31,7 +31,7 @@ describe('help', function() {
         afterEach(function() {
             cordova.removeAllListeners('results');
         });
-        describe('emit results', function (done) {
+        describe('emit results', function () {
             allcommands.forEach(function (k) {
                 it(k, function(done) {
                     cordova.on('results', function(h) {
@@ -44,7 +44,7 @@ describe('help', function() {
                 });
             });
         });
-        describe('not have overly long lines:', function (done) {
+        describe('not have overly long lines:', function () {
             allcommands.forEach(function (k) {
                 it(k || '(default)', function(done) {
                     cordova.on('results', function(h) {
@@ -57,7 +57,7 @@ describe('help', function() {
                 });
             });
         });
-        describe('use cordova-cli instead of cordova:', function (done) {
+        describe('use cordova-cli instead of cordova:', function () {
             var binname = cordova.binname,
                 testname = 'testgap';
             beforeEach(function() {

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,8 @@
+{
+    "spec_dir": "spec",
+    "spec_files": [
+        "**/*[sS]pec.js"
+    ],
+    "stopSpecOnExpectationFailure": false,
+    "random": false
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,6 @@
 
 
 var path = require('path'),
-    fs = require('fs'),
     help = require('./help'),
     nopt,
     _,
@@ -38,6 +37,9 @@ var cordova_lib = require('cordova-lib'),
     cordova = cordova_lib.cordova,
     events = cordova_lib.events,
     logger = require('cordova-common').CordovaLogger.get();
+
+var msg,
+    badPlatforms;
 
 
 /*
@@ -178,10 +180,10 @@ function handleTelemetryCmd(subcommand, isOptedIn) {
     try {
         if (turnOn) {
             telemetry.turnOn();
-            console.log("Thanks for opting into telemetry to help us improve cordova.");
+            console.log('Thanks for opting into telemetry to help us improve cordova.');
         } else {
             telemetry.turnOff();
-            console.log("You have been opted out of telemetry. To change this, run: cordova telemetry on.");
+            console.log('You have been opted out of telemetry. To change this, run: cordova telemetry on.');
         }
     } catch (ex) {
         cmdSuccess = false;
@@ -288,7 +290,7 @@ function cli(inputArgs) {
     }
 
     if (/^v0.\d+[.\d+]*/.exec(process.version)) { // matches v0.* 
-        var msg = 'Warning: using node version ' + process.version +
+        msg = 'Warning: using node version ' + process.version +
                 ' which has been deprecated. Please upgrade to the latest node version available (v6.x is recommended).';
         logger.warn(msg);
     }
@@ -312,8 +314,8 @@ function cli(inputArgs) {
     var undashed = remain.slice(0, remain.length - unparsedArgs.length);
     var cmd = undashed[0];
     var subcommand;
-    var msg;
     var known_platforms = Object.keys(cordova_lib.cordova_platforms);
+    msg = '';
 
     if ( !cmd || cmd == 'help' || args.help ) {
         if (!args.help && remain[0] == 'help') {
@@ -344,7 +346,7 @@ function cli(inputArgs) {
     if (cmd == 'emulate' || cmd == 'build' || cmd == 'prepare' || cmd == 'compile' || cmd == 'run' || cmd === 'clean') {
         // All options without dashes are assumed to be platform names
         opts.platforms = undashed.slice(1);
-        var badPlatforms = _.difference(opts.platforms, known_platforms);
+        badPlatforms = _.difference(opts.platforms, known_platforms);
         if( !_.isEmpty(badPlatforms) ) {
             msg = 'Unknown platforms: ' + badPlatforms.join(', ');
             throw new CordovaError(msg);
@@ -362,7 +364,7 @@ function cli(inputArgs) {
     } else if (cmd === 'requirements') {
         // All options without dashes are assumed to be platform names
         opts.platforms = undashed.slice(1);
-        var badPlatforms = _.difference(opts.platforms, known_platforms);
+        badPlatforms = _.difference(opts.platforms, known_platforms);
         if( !_.isEmpty(badPlatforms) ) {
             msg = 'Unknown platforms: ' + badPlatforms.join(', ');
             throw new CordovaError(msg);
@@ -413,7 +415,7 @@ function cli(inputArgs) {
                 // CB-9171
                 var eq = s.indexOf('=');
                 if (eq == -1)
-                    throw new CordovaError("invalid variable format: " + s);
+                    throw new CordovaError('invalid variable format: ' + s);
                 var key = s.substr(0, eq).toUpperCase();
                 var val = s.substr(eq + 1, s.length);
                 cli_vars[key] = val;

--- a/src/create.js
+++ b/src/create.js
@@ -36,10 +36,10 @@ CordovaCliCreate.prototype.run = function (args, undashed) {
     cfg = this.parseConfig(undashed[4]);
     
     // create(dir, id, name, cfg)
-    cordova.raw.create( undashed[1]  // dir to create the project in
-                      , undashed[2]  // App id
-                      , undashed[3]  // App name
-                      , cfg
+    cordova.raw.create(undashed[1] , // dir to create the project in
+                       undashed[2] , // App id
+                       undashed[3] , // App name
+                       cfg
     ).done();
 };
 
@@ -65,7 +65,7 @@ CordovaCliCreate.prototype.parseConfig = function (jsondata) {
 CordovaCliCreate.prototype.customWww = function (args) {
 
     // handle custom www
-    if (customWww = args['copy-from'] || args['link-to']) {
+    if (!!(customWww = args['copy-from'] || args['link-to'])) {
 
         if (customWww.indexOf(':') != -1) {
             throw new CordovaError(

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -46,14 +46,14 @@ function showPrompt() {
 
     var deferred = Q.defer();
     
-    var msg = "May Cordova anonymously report usage statistics to improve the tool over time?";
+    var msg = 'May Cordova anonymously report usage statistics to improve the tool over time?';
     insight.askPermission(msg, function (unused, optIn) {
         var EOL = require('os').EOL;
         if (optIn) {
-            console.log(EOL + "Thanks for opting into telemetry to help us improve cordova.");
+            console.log(EOL + 'Thanks for opting into telemetry to help us improve cordova.');
             track('telemetry', 'on', 'via-cli-prompt-choice', 'successful');
         } else {
-            console.log(EOL + "You have been opted out of telemetry. To change this, run: cordova telemetry on.");
+            console.log(EOL + 'You have been opted out of telemetry. To change this, run: cordova telemetry on.');
             // Always track telemetry opt-outs! (whether opted-in or opted-out)
             track('telemetry', 'off', 'via-cli-prompt-choice', 'successful');
         }
@@ -100,7 +100,8 @@ function isOptedIn() {
  * Has the user already answered the telemetry prompt? (thereby opting in or out?)
  */
 function hasUserOptedInOrOut() {
-    return !(insight.optOut === undefined);
+    var insightOptOut = insight.optOut === undefined;
+    return !(insightOptOut);
 }
 
 /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Updated tests to function with jasmine instead of jasmine-node

### What testing has been done on this change?


### Checklist
- [X ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X ] Added automated test coverage as appropriate for this change.

…node