### PR TITLE
CB-12008 : made autosave the default for platform and plugin add/rm and included jasmine tests

### DIFF
--- a/doc/cordova.txt
+++ b/doc/cordova.txt
@@ -39,8 +39,10 @@ Options
 
 Examples
     cordova-cli create myApp org.apache.cordova.myApp myApp
-    cordova-cli plugin add cordova-plugin-camera --save
-    cordova-cli platform add android --save
+    cordova-cli plugin add cordova-plugin-camera
+    cordova-cli platform add android
+    cordova-cli plugin add cordova-plugin-camera --nosave
+    cordova-cli platform add android --nosave
     cordova-cli requirements android    
     cordova-cli build android --verbose
     cordova-cli run android

--- a/doc/platform.txt
+++ b/doc/platform.txt
@@ -4,8 +4,11 @@ Synopsis
 
 Manage project platforms
 
-    add <plat-spec> [...].............. Add specified platforms
-        --save ........................ Save specified platforms into config.xml after installing them
+    add <plat-spec> [...].............. Add specified platforms and save platforms
+                                        into config.xml & package.json after installing them
+
+        --nosave ...................... Prevent saving platforms into
+                                        config.xml & package.json after installing them
 
         --link ........................ When <plat-spec> is a local path, links the platform
                                         library directly instead of making a copy of it (support
@@ -18,7 +21,9 @@ Manage project platforms
 
 
     remove <platform> [...] ........... Remove specified platforms
-        --save ........................ Delete specified platforms from config.xml after removing them
+        --nosave ...................... Prevent deleting specified platforms from 
+                                        config.xml & package.json after removing them
+
         --fetch ....................... Removes the plugin from the project's node_modules directory.
                                         Runs `npm uninstall` under the hood.
 
@@ -26,14 +31,13 @@ Manage project platforms
     update <plat-spec> ................ Update the version of Cordova used for a specific platform;
                                         update to the latest <version> if no <plat-spec> is specified
 
-        --save ........................ Save the latest versions for specified platforms into config.xml
-
         --fetch ....................... Fetches the plugin into the project's node_modules directory. 
                                         Uses `npm install` to do the fetching.
 
     list .............................. List all installed and available platforms
     check ............................. List platforms which can be updated by `cordova-cli platform update`
-    save .............................. Save version of all platforms added to config.xml
+    nosave ............................ Prevents saving version of all platforms added to 
+                                        config.xml & package.json
 
 
 Syntax
@@ -51,10 +55,10 @@ Aliases
     ls -> list
 
 Examples
-    cordova-cli platform add android ios --save
-    cordova-cli platform add android@^5.0.0 --save
-    cordova-cli platform add https://github.com/myfork/cordova-android.git#4.0.0 --save
-    cordova-cli platform add ../android --save
-    cordova-cli platform add ../cordova-android.tgz --save
-    cordova-cli platform rm android --save
+    cordova-cli platform add android ios
+    cordova-cli platform add android@^5.0.0
+    cordova-cli platform add https://github.com/myfork/cordova-android.git#4.0.0
+    cordova-cli platform add ../android
+    cordova-cli platform add ../cordova-android.tgz
+    cordova-cli platform rm android --nosave
     cordova-cli platform ls

--- a/doc/plugin.txt
+++ b/doc/plugin.txt
@@ -4,7 +4,8 @@ Synopsis
 
 Manage project plugins
 
-    add <plugin-spec> [...] ............ Add specified plugins
+    add <plugin-spec> [...] ............ Add specified plugins and save them to 
+                                         config.xml & package.json.
         --searchpath <directory> ....... When looking up plugins by ID, look in this directory and
                                          each of its subdirectories before hitting the registry.
                                          Multiple search paths can be specified.
@@ -14,7 +15,8 @@ Manage project plugins
         --link ......................... When installing from a local path, creates a symbolic link
                                          instead of copying files. The extent to which files are linked
                                          varies by platform. Useful for plugin development.
-        --save ......................... Save the information for specified plugin into config.xml
+        --nosave ....................... Prevent saving the information for specified plugin 
+                                         into config.xml & package.json.
         --shrinkwrap ................... Used together with --save, saves the
                                          installed version numbers to config.xml
         --browserify ................... Compile plugin JS at build time using
@@ -27,8 +29,10 @@ Manage project plugins
                                          node_modules directory. Uses
                                          `npm install` to do the fetching
 
-    remove <pluginid>|<name> [...] ..... Remove plugins with the given IDs/name.
-        --save ......................... Remove the information for specified plugin from config.xml
+    remove <pluginid>|<name> [...] ..... Remove plugins with the given IDs/name and 
+                                         removes the information for specified plugin from config.xml & package.json.
+        --nosave ....................... Prevents removing the information for
+                                         specified plugin from config.xml & package.json.
 
         --fetch ........................ Removes the plugin from the project's
                                          node_modules directory. Uses
@@ -37,6 +41,7 @@ Manage project plugins
 
     list .............................. List currently installed plugins
     save .............................. Saves the information for all currently added plugins to config.xml
+
     search [<keyword>] [...] .......... Search http://plugins.cordova.io for plugins matching the keywords
 
 Syntax
@@ -55,10 +60,10 @@ Aliases
     ls -> list
 
 Examples
-    cordova-cli plugin add cordova-plugin-camera cordova-plugin-file --save --searchpath ~/plugins
-    cordova-cli plugin add cordova-plugin-camera@^2.0.0 --save
-    cordova-cli plugin add https://github.com/myfork/cordova-plugin-camera.git#2.1.0 --save
-    cordova-cli plugin add ../cordova-plugin-camera --save
-    cordova-cli plugin add ../cordova-plugin-camera.tgz --save
-    cordova-cli plugin rm camera --save
+    cordova-cli plugin add cordova-plugin-camera cordova-plugin-file --nosave --searchpath ~/plugins
+    cordova-cli plugin add cordova-plugin-camera@^2.0.0 --nosave
+    cordova-cli plugin add https://github.com/myfork/cordova-plugin-camera.git#2.1.0 --nosave
+    cordova-cli plugin add ../cordova-plugin-camera --nosave
+    cordova-cli plugin add ../cordova-plugin-camera.tgz --nosave
+    cordova-cli plugin rm camera --nosave
     cordova-cli plugin ls

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -80,12 +80,12 @@ Certain commands have options (`platformOpts`) that are specific to a particular
         # Create a cordova project
         cordova create myApp com.myCompany.myApp myApp
         cd myApp
-        # Add camera plugin to the project and remember that in config.xml
-        cordova plugin add cordova-plugin-camera --save
+        # Add camera plugin to the project and remember that in config.xml & package.json
+        cordova plugin add cordova-plugin-camera
         # Add camera plugin to the project and remember that in config.xml. Use npm install to fetch.
         cordova plugin add cordova-plugin-camera --save --fetch
-        # Add android platform to the project and remember that in config.xml
-        cordova platform add android --save
+        # Add android platform to the project and remember that in config.xml & package.json.
+        cordova platform add android
         # Add android platform to the project and remember that in config.xml. Use npm install to fetch.
         cordova platform add android --save --fetch
         # Check to see if your system is configured for building android platform.
@@ -187,7 +187,7 @@ After building the Android and iOS projects, the Android application will contai
 
 #### Version control
 
-It is recommended not to check in `platforms/` and `plugins/` directories into version control as they are considered a build artifact. Instead, you should save the platform/plugin spec in the `config.xml` and they will be downloaded when on the machine when `cordova prepare` is invoked.
+It is recommended not to check in `platforms/` and `plugins/` directories into version control as they are considered a build artifact. Your platforms and plugins will be saved in config.xml & package.json automatically. These platforms/plugins will be downloaded when on the machine when `cordova prepare` is invoked.
 
 ### Examples
 
@@ -221,11 +221,11 @@ cordova {platform | platforms} [
 | Sub-command           | Option | Description |
 ------------------------|-------------|------|
 | add `<platform-spec>` [...] |  | Add specified platforms |
-|     | --save                   | Save `<platform-spec>` into `config.xml` after installing them using `<engine>` tag |
+|     | --nosave                 | Do not save `<platform-spec>` into `config.xml` & `package.json` after installing them using `<engine>` tag |
 |     | --link=`<path>`          | When `<platform-spec>` is a local path, links the platform library directly instead of making a copy of it (support varies by platform; useful for platform development)
 |     | --fetch                  | Fetches the platform using `npm install` and stores it into the apps `node_modules` directory |
 | remove `<platform>` [...] |    | Remove specified platforms |
-|     | --save                   | Delete specified platforms from `config.xml` after removing them |
+|     | --nosave                 | Do not delete specified platforms from `config.xml` & `package.json` after removing them |
 |     | --fetch                  | Removes the platform using `npm uninstall` and removes it from the apps `node_modules` directory |
 | update `platform` [...] |      | Update specified platforms |
 |     | --save                   | Updates the version specified in `config.xml` |
@@ -268,18 +268,18 @@ There are a number of ways to specify a platform:
 
 ### Examples
 
-- Add pinned version of the `android` and `ios` platform and save the downloaded version to `config.xml`:
+- Add pinned version of the `android` and `ios` platform and save the downloaded version to `config.xml` & `package.json`:
 
-        cordova platform add android ios --save
+        cordova platform add android ios
 
-- Add pinned version of the `android` and `ios` platform and save the downloaded version to `config.xml`. Install
+- Add pinned version of the `android` and `ios` platform and save the downloaded version to `config.xml` & `package.json`. Install
 to the project using `npm install` and store it in the apps `node_modules` directory:
 
         cordova platform add android ios --save --fetch
 
-- Add `android` platform with [semver](http://semver.org/) version ^5.0.0 and save it to `config.xml`:
+- Add `android` platform with [semver](http://semver.org/) version ^5.0.0 and save it to `config.xml` & `package.json`:
 
-        cordova platform add android@^5.0.0 --save
+        cordova platform add android@^5.0.0
 
 - Add platform by cloning the specified git repo and checkout to the `4.0.0` tag:
 
@@ -293,11 +293,15 @@ to the project using `npm install` and store it in the apps `node_modules` direc
 
         cordova platform add ../cordova-android.tgz
 
-- Remove `android` platform from the project and from `config.xml`:
+- Remove `android` platform from the project and remove from `config.xml` & `package.json`:
 
-        cordova platform rm android --save
+        cordova platform rm android
 
-- Remove `android` platform from the project and from `config.xml`. Run `npm uninstall` to remove it
+- Remove `android` platform from the project and do NOT remove from `config.xml` & `package.json`:
+
+        cordova platform rm android --nosave
+
+- Remove `android` platform from the project and from `config.xml` & `package.json`. Run `npm uninstall` to remove it
 from the `node_modules` directory.
 
         cordova platform rm android --save --fetch
@@ -306,7 +310,7 @@ from the `node_modules` directory.
 
         cordova platform ls
 
-- Save versions of all platforms currently added to the project to `config.xml`.
+- Save versions of all platforms currently added to the project to `config.xml` & `package.json`
 
         cordova platform save
 
@@ -334,12 +338,12 @@ cordova {plugin | plugins} [
 |       |--searchpath `<directory>` | When looking up plugins by ID, look in this directory and each of its subdirectories before hitting the registry. Multiple search paths can be specified. Use ':' as a separator in `*nix` based systems and ';' for Windows.
 |       |--noregistry             | Don't search the registry for plugins.
 |       |--link                   | When installing from a local path, creates a symbolic link instead of copying files. The extent to which files are linked varies by platform. Useful for plugin development.
-|       |--save                   | Save the `<plugin-spec>` as part of the `plugin` element  into `config.xml`.
+|       |--nosave                 | Do NOT save the `<plugin-spec>` as part of the `plugin` element  into `config.xml` or `package.json`.
 |       |--browserify             | Compile plugin JS at build time using browserify instead of runtime.
 |       |--force                  | _Introduced in version 6.1._ Forces copying source files from the plugin even if the same file already exists in the target directory.
 |       |--fetch                 | Fetches the plugin using `npm install` and stores it into the apps `node_modules` directory |
 | remove `<pluginid>|<name>` [...]| | Remove plugins with the given IDs/name.
-|       |--save                    | Remove the specified plugin from config.xml
+|       |--nosave                 | Do NOT remove the specified plugin from config.xml or package.json
 |       |--fetch                  | Removes the plugin using `npm uninstall` and removes it from the apps `node_modules` directory |
 |list                           |  | List currently installed plugins
 |search `[<keyword>]` [...]     |  | Search http://plugins.cordova.io for plugins matching the keywords
@@ -367,27 +371,23 @@ When adding a plugin to a project, the CLI will resolve the plugin
 based on the following criteria (listed in order of precedence):
 
 1. The `plugin-spec` given in the command (e.g. `cordova plugin add pluginID@version`)
-2. The `plugin-spec` saved in `config.xml` (i.e. if the plugin was previously added with `--save`)
+2. The `plugin-spec` saved in `config.xml` & `package.json` (i.e. if the plugin was previously added without `--nosave`)
 3. As of Cordova version 6.1, the latest plugin version published to npm that the current project can support (only applies to plugins that list their [Cordova dependencies] in their `package.json`)
 4. The latest plugin version published to npm
 
 ### Examples
 
-- Add `cordova-plugin-camera` and `cordova-plugin-file` to the project and save it to `config.xml`. Use `../plugins` directory to search for the plugins.
+- Add `cordova-plugin-camera` and `cordova-plugin-file` to the project and it be be saved to `config.xml` & `package.json`. Use `../plugins` directory to search for the plugins.
 
         cordova plugin add cordova-plugin-camera cordova-plugin-file --save --searchpath ../plugins
 
-- Add `cordova-plugin-camera` with [semver](http://semver.org/) version ^2.0.0 and save it to `config.xml`:
+- Add `cordova-plugin-camera` with [semver](http://semver.org/) version ^2.0.0 and save it to `config.xml` & `package.json`:
 
-        cordova plugin add cordova-plugin-camera@^2.0.0 --save
+        cordova plugin add cordova-plugin-camera@^2.0.0
 
 - Add `cordova-plugin-camera` with [semver](http://semver.org/) version ^2.0.0 and `npm install` it. It will be stored in the `node_modules` directory:
 
         cordova plugin add cordova-plugin-camera@^2.0.0 --fetch
-
-- Clone the specified git repo, checkout to tag `2.1.0`, look for plugin.xml in the `plugin` directory, and add it to the project. Save the `plugin-spec` to `config.xml`:
-
-        cordova plugin add https://github.com/apache/cordova-plugin-camera.git#2.1.0:plugin --save
 
 - Add the plugin from the specified local directory:
 
@@ -395,11 +395,15 @@ based on the following criteria (listed in order of precedence):
 
 - Add the plugin from the specified tarball file:
 
-        cordova plugin add ../cordova-plugin-camera.tgz --save
+        cordova plugin add ../cordova-plugin-camera.tgz
 
-- Remove the plugin from the project and the `config.xml`:
+- Remove the plugin from the project and the `config.xml` & `package.json`:
 
-        cordova plugin rm camera --save
+        cordova plugin rm camera
+
+- Remove the plugin from the project, but not the `config.xml` or `package.json`:
+
+        cordova plugin rm camera --nosave
 
 - Remove the plugin from the project and `npm uninstall` it. Removes it from the `node_modules` directory:
 

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -186,10 +186,61 @@ describe("cordova cli", function () {
             });
         });
 
-    });
-    
+        it("Test #015 : will pass save:false", function (done) {
+            cli(["node", "cordova", "plugin", "add", "device", "--nosave"], function () {
+                expect(cordova.raw.plugin).toHaveBeenCalledWith(
+                    "add",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
+                expect(opts.save).toBe(false);
+                done();
+            });
+        });
+
+        it("Test #016 : autosave is default and will pass save:true", function (done) {
+            cli(["node", "cordova", "plugin", "add", "device"], function () {
+                expect(cordova.raw.plugin).toHaveBeenCalledWith(
+                    "add",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
+                expect(opts.save).toBe(true);
+                done();
+            });
+        });
+
+        it("Test #017 : will pass save:false", function (done) {
+            cli(["node", "cordova", "plugin", "remove", "device", "--nosave"], function () {
+                expect(cordova.raw.plugin).toHaveBeenCalledWith(
+                    "remove",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
+                expect(opts.save).toBe(false);
+                done();
+            });
+        });
+
+        it("Test #018 : autosave is default and will pass save:true", function (done) {
+            cli(["node", "cordova", "plugin", "remove", "device"], function () {
+                expect(cordova.raw.plugin).toHaveBeenCalledWith(
+                    "remove",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
+                expect(opts.save).toBe(true);
+                done();
+            });
+        });
+    }); 
+
     describe("telemetry", function() {
-       it("Test#015 : skips prompt when user runs 'cordova telemetry X'", function(done) {
+       it("Test#019 : skips prompt when user runs 'cordova telemetry X'", function(done) {
            var wasPromptShown = false;
            spyOn(telemetry, "showPrompt").and.callFake(function () {
                wasPromptShown = true;
@@ -203,7 +254,7 @@ describe("cordova cli", function () {
            });         
        });
        
-       it("Test#016 : is NOT collected when user runs 'cordova telemetry on' while NOT opted-in", function(done) {
+       it("Test#020 : is NOT collected when user runs 'cordova telemetry on' while NOT opted-in", function(done) {
            spyOn(telemetry, "isOptedIn").and.returnValue(false);
            spyOn(telemetry, "isCI").and.returnValue(false);
            
@@ -215,7 +266,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#017 : is collected when user runs 'cordova telemetry off' while opted-in", function(done) {
+       it("Test#021 : is collected when user runs 'cordova telemetry off' while opted-in", function(done) {
            spyOn(telemetry, "isOptedIn").and.returnValue(true);
            spyOn(telemetry, "isCI").and.returnValue(false);
            
@@ -227,7 +278,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#018 : tracks platforms/plugins subcommands", function(done) {
+       it("Test#022 : tracks platforms/plugins subcommands", function(done) {
            spyOn(telemetry, "isOptedIn").and.returnValue(true);
            spyOn(telemetry, "isCI").and.returnValue(false);
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
@@ -241,7 +292,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#019 : shows prompt if user neither opted in or out yet", function(done) {
+       it("Test#023 : shows prompt if user neither opted in or out yet", function(done) {
            spyOn(cordova.raw, "prepare").and.returnValue(Q());
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(false);
            
@@ -257,7 +308,7 @@ describe("cordova cli", function () {
 
        // ToDO: Figure out a way to modify default timeout
        // ... Timeout overriding isn't working anymore due to a bug with jasmine-node
-       xit("Test#020 : opts-out if prompt times out AND it tracks opt-out", function(done) {
+       xit("Test#024 : opts-out if prompt times out AND it tracks opt-out", function(done) {
            // Remove any optOut settings that might have been saved
            // ... and force prompt to be shown
            telemetry.clear();
@@ -272,7 +323,7 @@ describe("cordova cli", function () {
            });
        }/*, 45000*/);
        
-       it("Test#021 : is NOT collected in CI environments and doesn't prompt", function(done) {
+       it("Test#025 : is NOT collected in CI environments and doesn't prompt", function(done) {
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
            spyOn(telemetry, "isOptedIn").and.returnValue(true);
            spyOn(telemetry, "isCI").and.returnValue(true);
@@ -287,7 +338,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#022 : is NOT collected when --no-telemetry flag found and doesn't prompt", function(done) {
+       it("Test#026 : is NOT collected when --no-telemetry flag found and doesn't prompt", function(done) {
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(false);
            spyOn(telemetry, "isOptedIn").and.returnValue(true);
            spyOn(telemetry, "isCI").and.returnValue(false);
@@ -302,7 +353,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#023 : is NOT collected if user opted out", function(done) {
+       it("Test#027 : is NOT collected if user opted out", function(done) {
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
            spyOn(telemetry, "isOptedIn").and.returnValue(false);
            spyOn(telemetry, "isCI").and.returnValue(false);
@@ -317,7 +368,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#024 : is collected if user opted in", function(done) {
+       it("Test#028 : is collected if user opted in", function(done) {
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
            spyOn(telemetry, "isOptedIn").and.returnValue(true);
            spyOn(telemetry, "isCI").and.returnValue(false);
@@ -332,7 +383,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#025 : track opt-out that happened via 'cordova telemetry off' even if user is NOT opted-in ", function(done) {
+       it("Test#029 : track opt-out that happened via 'cordova telemetry off' even if user is NOT opted-in ", function(done) {
            spyOn(telemetry, "isCI").and.returnValue(false);
            spyOn(telemetry, "isOptedIn").and.returnValue(false); // same as calling `telemetry.turnOff();`
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
@@ -348,3 +399,61 @@ describe("cordova cli", function () {
        });
     });
 });
+
+    describe("platform", function () {
+        beforeEach(function () {
+            spyOn(cordova.raw, "platform").and.returnValue(Q());
+        });
+
+        it("Test #030 : autosave is the default setting for platform add", function (done) {
+            cli(["node", "cordova", "platform", "add", "ios"], function () {
+                expect(cordova.raw.platform).toHaveBeenCalledWith(
+                    "add",
+                    ["ios"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.platform.calls.argsFor(0)[2];
+                expect(opts.save).toBe(true);
+                done();
+            });
+        });
+
+        it("Test #031 : platform is not saved when --nosave is passed in", function (done) {
+            cli(["node", "cordova", "platform", "add", "ios", "--nosave"], function () {
+                expect(cordova.raw.platform).toHaveBeenCalledWith(
+                    "add",
+                    ["ios"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.platform.calls.argsFor(0)[2];
+                expect(opts.save).toBe(false);
+                done();
+            });
+        });
+
+        it("Test #032 : autosave is the default setting for platform remove", function (done) {
+            cli(["node", "cordova", "platform", "remove", "ios"], function () {
+                expect(cordova.raw.platform).toHaveBeenCalledWith(
+                    "remove",
+                    ["ios"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.platform.calls.argsFor(0)[2];
+                expect(opts.save).toBe(true);
+                done();
+            });
+        });
+
+        it("Test #033 : platform is not removed when --nosave is passed in", function (done) {
+            cli(["node", "cordova", "platform", "remove", "ios", "--nosave"], function () {
+                expect(cordova.raw.platform).toHaveBeenCalledWith(
+                    "remove",
+                    ["ios"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.platform.calls.argsFor(0)[2];
+                expect(opts.save).toBe(false);
+                done();
+            });
+        });
+    }); 

--- a/src/cli.js
+++ b/src/cli.js
@@ -219,6 +219,45 @@ function handleTelemetryCmd(subcommand, isOptedIn) {
 
 function cli(inputArgs) {
     // When changing command line arguments, update doc/help.txt accordingly.
+    var knownOpts =
+        { 'verbose' : Boolean
+        , 'version' : Boolean
+        , 'help' : Boolean
+        , 'silent' : Boolean
+        , 'experimental' : Boolean
+        , 'noregistry' : Boolean
+        , 'nohooks': Array
+        , 'shrinkwrap' : Boolean
+        , 'copy-from' : String
+        , 'link-to' : path
+        , 'searchpath' : String
+        , 'variable' : Array
+        , 'link': Boolean
+        , 'force': Boolean
+        // Flags to be passed to `cordova build/run/emulate`
+        , 'debug' : Boolean
+        , 'release' : Boolean
+        , 'archs' : String
+        , 'device' : Boolean
+        , 'emulator': Boolean
+        , 'target' : String
+        , 'browserify': Boolean
+        , 'noprepare': Boolean
+        , 'fetch': Boolean
+        , 'nobuild': Boolean
+        , 'list': Boolean
+        , 'buildConfig' : String
+        , 'template' : String
+        , 'nosave' : Boolean
+        };
+
+    var shortHands =
+        { 'd' : '--verbose'
+        , 'v' : '--version'
+        , 'h' : '--help'
+        , 'src' : '--copy-from'
+        , 't' : '--template'
+        };
 
     checkForUpdates();
 
@@ -390,6 +429,12 @@ function cli(inputArgs) {
             });
         }
 
+        if (args.nosave) {
+            args.save = false;
+        } else {
+            args.save = true;
+        }
+        
         var download_opts = { searchpath : args.searchpath
                             , noregistry : args.noregistry
                             , nohooks : args.nohooks
@@ -397,7 +442,7 @@ function cli(inputArgs) {
                             , browserify: args.browserify || false
                             , fetch: args.fetch || false
                             , link: args.link || false
-                            , save: args.save || false
+                            , save: args.save
                             , shrinkwrap: args.shrinkwrap || false
                             , force: args.force || false
         };

--- a/src/cli.js
+++ b/src/cli.js
@@ -218,46 +218,6 @@ function handleTelemetryCmd(subcommand, isOptedIn) {
 }
 
 function cli(inputArgs) {
-    // When changing command line arguments, update doc/help.txt accordingly.
-    var knownOpts =
-        { 'verbose' : Boolean
-        , 'version' : Boolean
-        , 'help' : Boolean
-        , 'silent' : Boolean
-        , 'experimental' : Boolean
-        , 'noregistry' : Boolean
-        , 'nohooks': Array
-        , 'shrinkwrap' : Boolean
-        , 'copy-from' : String
-        , 'link-to' : path
-        , 'searchpath' : String
-        , 'variable' : Array
-        , 'link': Boolean
-        , 'force': Boolean
-        // Flags to be passed to `cordova build/run/emulate`
-        , 'debug' : Boolean
-        , 'release' : Boolean
-        , 'archs' : String
-        , 'device' : Boolean
-        , 'emulator': Boolean
-        , 'target' : String
-        , 'browserify': Boolean
-        , 'noprepare': Boolean
-        , 'fetch': Boolean
-        , 'nobuild': Boolean
-        , 'list': Boolean
-        , 'buildConfig' : String
-        , 'template' : String
-        , 'nosave' : Boolean
-        };
-
-    var shortHands =
-        { 'd' : '--verbose'
-        , 'v' : '--version'
-        , 'h' : '--help'
-        , 'src' : '--copy-from'
-        , 't' : '--template'
-        };
 
     checkForUpdates();
 
@@ -434,7 +394,7 @@ function cli(inputArgs) {
         } else {
             args.save = true;
         }
-        
+
         var download_opts = { searchpath : args.searchpath
                             , noregistry : args.noregistry
                             , nohooks : args.nohooks


### PR DESCRIPTION
CB-12008 : made autosave the default for platform and plugin add/rm and included jasmine tests

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Makes save the default setting for platform and plugin add/remove. Use --nosave if you do not want to add or remove.

### What testing has been done on this change?
New jasmine tests added (platform and plugin add and remove with/without --nosave).

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
