### PR TITLE
CB-12570 : fetch is true by default, --nofetch flag added

### DIFF
--- a/doc/cordova.txt
+++ b/doc/cordova.txt
@@ -47,3 +47,5 @@ Examples
     cordova-cli build android --verbose
     cordova-cli run android
     cordova-cli build android --release -- --keystore="..\android.keystore" --storePassword=android --alias=mykey
+    cordova-cli platform add ios --nofetch
+    cordova-cli plugin add cordova-plugin-camera --nofetch

--- a/doc/platform.txt
+++ b/doc/platform.txt
@@ -14,32 +14,25 @@ Manage project platforms
                                         library directly instead of making a copy of it (support
                                         varies by platform; useful for platform development)
         
-        --fetch ....................... Fetches the plugin into the project's node_modules directory. 
-                                        Uses `npm install` to do the fetching.
-
-
-
+        --nofetch ..................... Prevent fetching the plugin into the project's node_modules 
+                                        directory. Prevent using `npm install` to do the fetching.
 
     remove <platform> [...] ........... Remove specified platforms
+
         --nosave ...................... Prevent deleting specified platforms from 
                                         config.xml & package.json after removing them
-
-        --fetch ....................... Removes the plugin from the project's node_modules directory.
-                                        Runs `npm uninstall` under the hood.
-
+        --nofetch ..................... Prevent removing the plugin from the project's node_modules 
+                                        directory. Prevent running `npm uninstall` under the hood.
 
     update <plat-spec> ................ Update the version of Cordova used for a specific platform;
                                         update to the latest <version> if no <plat-spec> is specified
-
-        --fetch ....................... Fetches the plugin into the project's node_modules directory. 
-                                        Uses `npm install` to do the fetching.
 
     list .............................. List all installed and available platforms
     check ............................. List platforms which can be updated by `cordova-cli platform update`
     nosave ............................ Prevents saving version of all platforms added to 
                                         config.xml & package.json
-
-
+    nofetch ........................... Prevents fetching the plugin into the project's node_modules 
+                                        directory.
 Syntax
     <plat-spec> : <platform>[@<version>]|<path>|<url>[#<commit-ish>]
 
@@ -62,3 +55,5 @@ Examples
     cordova-cli platform add ../cordova-android.tgz
     cordova-cli platform rm android --nosave
     cordova-cli platform ls
+    cordova-cli platform add android --nofetch
+    cordova-cli platform rm android --nofetch

--- a/doc/platform.txt
+++ b/doc/platform.txt
@@ -15,14 +15,16 @@ Manage project platforms
                                         varies by platform; useful for platform development)
         
         --nofetch ..................... Prevent fetching the plugin into the project's node_modules 
-                                        directory. Prevent using `npm install` to do the fetching.
+                                        directory. Uses older fetching method (pre cordova-7) 
+                                        instead of using npm install under the hood
 
     remove <platform> [...] ........... Remove specified platforms
 
         --nosave ...................... Prevent deleting specified platforms from 
                                         config.xml & package.json after removing them
         --nofetch ..................... Prevent removing the plugin from the project's node_modules 
-                                        directory. Prevent running `npm uninstall` under the hood.
+                                        directory. Uses older fetching method (pre cordova-7) 
+                                        instead of using npm install under the hood
 
     update <plat-spec> ................ Update the version of Cordova used for a specific platform;
                                         update to the latest <version> if no <plat-spec> is specified
@@ -31,8 +33,6 @@ Manage project platforms
     check ............................. List platforms which can be updated by `cordova-cli platform update`
     nosave ............................ Prevents saving version of all platforms added to 
                                         config.xml & package.json
-    nofetch ........................... Prevents fetching the plugin into the project's node_modules 
-                                        directory.
 Syntax
     <plat-spec> : <platform>[@<version>]|<path>|<url>[#<commit-ish>]
 

--- a/doc/plugin.txt
+++ b/doc/plugin.txt
@@ -25,17 +25,17 @@ Manage project plugins
         --force ........................ Forces copying source files from the plugin even if the
                                          same file already exists in the target directory.
 
-        --fetch ........................ Fetches the plugin into the project's
-                                         node_modules directory. Uses
-                                         `npm install` to do the fetching
+        --nofetch ...................... Prevents fetching the plugin into the project's
+                                         node_modules directory. Prevents using
+                                         `npm install` to do the fetching.
 
     remove <pluginid>|<name> [...] ..... Remove plugins with the given IDs/name and 
                                          removes the information for specified plugin from config.xml & package.json.
         --nosave ....................... Prevents removing the information for
                                          specified plugin from config.xml & package.json.
 
-        --fetch ........................ Removes the plugin from the project's
-                                         node_modules directory. Uses
+        --nofetch ...................... Prevents removing the plugin from the project's
+                                         node_modules directory. Prevents using
                                          `npm uninstall` under the hood.
 
 
@@ -67,3 +67,5 @@ Examples
     cordova-cli plugin add ../cordova-plugin-camera.tgz --nosave
     cordova-cli plugin rm camera --nosave
     cordova-cli plugin ls
+    cordova-cli plugin add cordova-plugin-camera --nofetch
+    cordova-cli plugin rm cordova-plugin-camera --nofetch

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -80,14 +80,14 @@ Certain commands have options (`platformOpts`) that are specific to a particular
         # Create a cordova project
         cordova create myApp com.myCompany.myApp myApp
         cd myApp
-        # Add camera plugin to the project and remember that in config.xml & package.json
-        cordova plugin add cordova-plugin-camera
+        # Add camera plugin to the project and remember that in config.xml & package.json. Do not use npm install to fetch.
+        cordova plugin add cordova-plugin-camera --nofetch
         # Add camera plugin to the project and remember that in config.xml. Use npm install to fetch.
         cordova plugin add cordova-plugin-camera --save --fetch
         # Add android platform to the project and remember that in config.xml & package.json.
         cordova platform add android
-        # Add android platform to the project and remember that in config.xml. Use npm install to fetch.
-        cordova platform add android --save --fetch
+        # Add android platform to the project and remember that in config.xml. Do not use npm install to fetch.
+        cordova platform add android --save --nofetch
         # Check to see if your system is configured for building android platform.
         cordova requirements android
         # Build the android and emit verbose logs.
@@ -223,13 +223,13 @@ cordova {platform | platforms} [
 | add `<platform-spec>` [...] |  | Add specified platforms |
 |     | --nosave                 | Do not save `<platform-spec>` into `config.xml` & `package.json` after installing them using `<engine>` tag |
 |     | --link=`<path>`          | When `<platform-spec>` is a local path, links the platform library directly instead of making a copy of it (support varies by platform; useful for platform development)
-|     | --fetch                  | Fetches the platform using `npm install` and stores it into the apps `node_modules` directory |
+|     | --nofetch                | Do not fetch the platform using `npm install` and do not store it into the apps `node_modules` directory |
 | remove `<platform>` [...] |    | Remove specified platforms |
 |     | --nosave                 | Do not delete specified platforms from `config.xml` & `package.json` after removing them |
-|     | --fetch                  | Removes the platform using `npm uninstall` and removes it from the apps `node_modules` directory |
+|     | --nofetch                | Prevent removing the platform using `npm uninstall` and prevent removing it from the apps `node_modules` directory |
 | update `platform` [...] |      | Update specified platforms |
 |     | --save                   | Updates the version specified in `config.xml` |
-|     | --fetch                  | Fetches the platform using `npm install` and stores it into the apps `node_modules` directory |
+|     | --nofetch                | Do not fetch the platform using `npm install` and do not store it into the apps `node_modules` directory |
 | list |                         | List all installed and available platforms |
 | check |                        | List platforms which can be updated by `cordova-cli platform update` |
 | save  |                        | Save `<platform-spec>` of all platforms added to config.xml |
@@ -272,10 +272,9 @@ There are a number of ways to specify a platform:
 
         cordova platform add android ios
 
-- Add pinned version of the `android` and `ios` platform and save the downloaded version to `config.xml` & `package.json`. Install
-to the project using `npm install` and store it in the apps `node_modules` directory:
+- Add pinned version of the `android` and `ios` platform and save the downloaded version to `config.xml` & `package.json`. Do not install to the project using `npm install` and do not store it in the apps `node_modules` directory:
 
-        cordova platform add android ios --save --fetch
+        cordova platform add android ios --nofetch
 
 - Add `android` platform with [semver](http://semver.org/) version ^5.0.0 and save it to `config.xml` & `package.json`:
 
@@ -301,10 +300,9 @@ to the project using `npm install` and store it in the apps `node_modules` direc
 
         cordova platform rm android --nosave
 
-- Remove `android` platform from the project and from `config.xml` & `package.json`. Run `npm uninstall` to remove it
-from the `node_modules` directory.
+- Remove `android` platform from the project and do NOT remove from `config.xml` & 'package.json. Do not run `npm uninstall` to remove it
 
-        cordova platform rm android --save --fetch
+        cordova platform rm android --nosave --nofetch
 
 - List available and installed platforms with version numbers. This is useful to find version numbers when reporting issues:
 
@@ -324,8 +322,8 @@ Manage project plugins
 
 ```bash
 cordova {plugin | plugins} [
-    add <plugin-spec> [..] {--searchpath=<directory> | --noregistry | --link | --save | --browserify | --force | --fetch} |
-    {remove | rm} {<pluginid> | <name>} --save --fetch |
+    add <plugin-spec> [..] {--searchpath=<directory> | --noregistry | --link | --save | --browserify | --force | --nofetch} |
+    {remove | rm} {<pluginid> | <name>} --save --nofetch |
     {list | ls} |
     search [<keyword>] |
     save |
@@ -341,10 +339,10 @@ cordova {plugin | plugins} [
 |       |--nosave                 | Do NOT save the `<plugin-spec>` as part of the `plugin` element  into `config.xml` or `package.json`.
 |       |--browserify             | Compile plugin JS at build time using browserify instead of runtime.
 |       |--force                  | _Introduced in version 6.1._ Forces copying source files from the plugin even if the same file already exists in the target directory.
-|       |--fetch                 | Fetches the plugin using `npm install` and stores it into the apps `node_modules` directory |
+|       |--nofetch                 | Do not fetch the plugin using `npm install` and do not store it into the apps `node_modules` directory |
 | remove `<pluginid>|<name>` [...]| | Remove plugins with the given IDs/name.
 |       |--nosave                 | Do NOT remove the specified plugin from config.xml or package.json
-|       |--fetch                  | Removes the plugin using `npm uninstall` and removes it from the apps `node_modules` directory |
+|       |--nofetch                | Do not remove the plugin using `npm uninstall` and do not remove it from the apps `node_modules` directory |
 |list                           |  | List currently installed plugins
 |search `[<keyword>]` [...]     |  | Search http://plugins.cordova.io for plugins matching the keywords
 |save                           |  | Save `<plugin-spec>` of all plugins currently added to the project
@@ -385,9 +383,9 @@ based on the following criteria (listed in order of precedence):
 
         cordova plugin add cordova-plugin-camera@^2.0.0
 
-- Add `cordova-plugin-camera` with [semver](http://semver.org/) version ^2.0.0 and `npm install` it. It will be stored in the `node_modules` directory:
+- Add `cordova-plugin-camera` with [semver](http://semver.org/) version ^2.0.0 and do not`npm install` it. It will not be stored in the `node_modules` directory:
 
-        cordova plugin add cordova-plugin-camera@^2.0.0 --fetch
+        cordova plugin add cordova-plugin-camera@^2.0.0 --nofetch
 
 - Add the plugin from the specified local directory:
 
@@ -405,9 +403,9 @@ based on the following criteria (listed in order of precedence):
 
         cordova plugin rm camera --nosave
 
-- Remove the plugin from the project and `npm uninstall` it. Removes it from the `node_modules` directory:
+- Do not remove the plugin from the project and `npm uninstall` it. Do not remove it from the `node_modules` directory:
 
-        cordova plugin rm camera --fetch
+        cordova plugin rm camera --nofetch
 
 - List all plugins installed in the project:
 

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -82,12 +82,10 @@ Certain commands have options (`platformOpts`) that are specific to a particular
         cd myApp
         # Add camera plugin to the project and remember that in config.xml & package.json. Do not use npm install to fetch.
         cordova plugin add cordova-plugin-camera --nofetch
-        # Add camera plugin to the project and remember that in config.xml. Use npm install to fetch.
-        cordova plugin add cordova-plugin-camera --save --fetch
-        # Add android platform to the project and remember that in config.xml & package.json.
-        cordova platform add android
-        # Add android platform to the project and remember that in config.xml. Do not use npm install to fetch.
-        cordova platform add android --save --nofetch
+        # Add camera plugin to the project and remember that in config.xml and package.json. Uses pre cordova@7 fetching methods instead of cordova-fetch which uses npm install under the hood.
+        cordova plugin add cordova-plugin-camera --nofetch
+        # Add android platform to the project and remember that in config.xml & package.json. Uses pre cordova@7 fetching methods instead of cordova-fetch which uses npm install under the hood
+        cordova platform add android --nofetch
         # Check to see if your system is configured for building android platform.
         cordova requirements android
         # Build the android and emit verbose logs.
@@ -403,7 +401,7 @@ based on the following criteria (listed in order of precedence):
 
         cordova plugin rm camera --nosave
 
-- Do not remove the plugin from the project and `npm uninstall` it. Do not remove it from the `node_modules` directory:
+- Remove the plugin from the project. Do not remove it from the node_modules directory and don't run npm uninstall under the hood:
 
         cordova plugin rm camera --nofetch
 

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -88,42 +88,42 @@ describe("cordova cli", function () {
 
         it("Test#005 : will call command with all arguments passed through", function (done) {
             cli(["node", "cordova", "build", "blackberry10", "--", "-k", "abcd1234"], function () {
-                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { argv: ['-k', 'abcd1234'] }, verbose: false, silent: false, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
+                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { argv: ['-k', 'abcd1234'], fetch: true }, verbose: false, silent: false, browserify: false, fetch: true, nohooks: [  ], searchpath: undefined });
                 done();
             });
         }, 60000);
 
         it("Test#006 : will consume the first instance of -d", function (done) {
             cli(["node", "cordova", "-d", "build", "blackberry10", "--", "-k", "abcd1234", "-d"], function () {
-                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '-d'] }, verbose: true, silent: false, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
+                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '-d'], fetch: true }, verbose: true, silent: false, browserify: false, fetch: true, nohooks: [  ], searchpath: undefined });
                 done();
             });
         });
 
         it("Test#007 : will consume the first instance of --verbose", function (done) {
             cli(["node", "cordova", "--verbose", "build", "blackberry10", "--", "-k", "abcd1234", "--verbose"], function () {
-                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '--verbose'] }, verbose: true, silent: false, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
+                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '--verbose'], fetch: true }, verbose: true, silent: false, browserify: false, fetch: true, nohooks: [  ], searchpath: undefined });
                 done();
             });
         });
 
         it("Test#008 : will consume the first instance of either --verbose or -d", function (done) {
             cli(["node", "cordova", "--verbose", "build", "blackberry10", "--", "-k", "abcd1234", "-d"], function () {
-                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '-d'] }, verbose: true, silent: false, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
+                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '-d'], fetch: true }, verbose: true, silent: false, browserify: false, fetch: true, nohooks: [  ], searchpath: undefined });
                 done();
             });
         });
 
         it("Test#009 : will consume the first instance of either --verbose or -d", function (done) {
             cli(["node", "cordova", "-d", "build", "blackberry10", "--", "-k", "abcd1234", "--verbose"], function () {
-                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '--verbose'] }, verbose: true, silent: false, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
+                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { verbose: true, argv: ['-k', 'abcd1234', '--verbose'], fetch: true }, verbose: true, silent: false, browserify: false, fetch: true, nohooks: [  ], searchpath: undefined });
                 done();
             });
         });
 
         it("Test#010 : will consume the first instance of --silent", function (done) {
             cli(["node", "cordova", "--silent", "build", "blackberry10", "--", "-k", "abcd1234", "--silent"], function () {
-                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { silent: true, argv: ['-k', 'abcd1234', '--silent'] }, verbose: false, silent: true, browserify: false, nohooks: [], searchpath: undefined, fetch: false });
+                expect(cordova.raw.build).toHaveBeenCalledWith({ platforms: ['blackberry10'], options: { silent: true, argv: ['-k', 'abcd1234', '--silent'], fetch: true }, verbose: false, silent: true, browserify: false, fetch: true, nohooks: [  ], searchpath: undefined });
                 done();
             });
         });
@@ -195,19 +195,6 @@ describe("cordova cli", function () {
                 );
                 var opts = cordova.raw.plugin.calls.argsFor(0)[2];
                 expect(opts.save).toBe(false);
-                done();
-            });
-        });
-
-        it("Test #016 : autosave is default and will pass save:true", function (done) {
-            cli(["node", "cordova", "plugin", "add", "device"], function () {
-                expect(cordova.raw.plugin).toHaveBeenCalledWith(
-                    "add",
-                    ["device"],
-                    jasmine.any(Object)
-                );
-                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
-                expect(opts.save).toBe(true);
                 done();
             });
         });
@@ -456,4 +443,30 @@ describe("cordova cli", function () {
                 done();
             });
         });
-    }); 
+
+        it("Test #036 : will pass fetch:false", function (done) {
+            cli(["node", "cordova", "platform", "add", "device", "--nofetch"], function () {
+              expect(cordova.raw.platform).toHaveBeenCalledWith(
+                  "add",
+                  ["device"],
+                  jasmine.any(Object)
+              );
+              var opts = cordova.raw.platform.calls.argsFor(0)[2];
+              expect(opts.fetch).toBe(false);
+              done();
+            });
+        });
+
+        it("Test #037 : fetch is true by default and will pass fetch:true", function (done) {
+            cli(["node", "cordova", "platform", "add", "device"], function () {
+                expect(cordova.raw.platform).toHaveBeenCalledWith(
+                    "add",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.platform.calls.argsFor(0)[2];
+                expect(opts.fetch).toBe(true);
+                done();
+            });
+        });
+    });

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -186,7 +186,20 @@ describe("cordova cli", function () {
             });
         });
 
-        it("Test #015 : will pass save:false", function (done) {
+        it("Test #015 : (add) will pass save:true", function (done) {
+            cli(["node", "cordova", "plugin", "add", "device"], function () {
+                expect(cordova.raw.plugin).toHaveBeenCalledWith(
+                    "add",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
+                expect(opts.save).toBe(true);
+                done();
+            });
+        });
+
+        it("Test #016 : (add) will pass save:false", function (done) {
             cli(["node", "cordova", "plugin", "add", "device", "--nosave"], function () {
                 expect(cordova.raw.plugin).toHaveBeenCalledWith(
                     "add",
@@ -199,10 +212,10 @@ describe("cordova cli", function () {
             });
         });
 
-        it("Test #017 : will pass save:false", function (done) {
+        it("Test #017: (remove) will pass save:false", function (done) {
             cli(["node", "cordova", "plugin", "remove", "device", "--nosave"], function () {
                 expect(cordova.raw.plugin).toHaveBeenCalledWith(
-                    "add",
+                    "remove",
                     ["device"],
                     jasmine.any(Object)
                 );
@@ -212,7 +225,20 @@ describe("cordova cli", function () {
             });
         });
 
-        it("Test #034 : (add) will pass fetch:false", function (done) {
+        it("Test #018 : (remove) autosave is default and will pass save:true", function (done) {
+            cli(["node", "cordova", "plugin", "remove", "device"], function () {
+                expect(cordova.raw.plugin).toHaveBeenCalledWith(
+                    "remove",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
+                expect(opts.save).toBe(true);
+                done();
+            });
+        });
+
+        it("Test #019 : (add) will pass fetch:false", function (done) {
             cli(["node", "cordova", "plugin", "add", "device", "--nofetch"], function () {
               expect(cordova.raw.plugin).toHaveBeenCalledWith(
                   "add",
@@ -225,20 +251,20 @@ describe("cordova cli", function () {
             });
         });
 
-        it("Test #035 : (add) fetch is true by default and will pass fetch:true", function (done) {
+        it("Test #020 : (add) fetch is true by default and will pass fetch:true", function (done) {
             cli(["node", "cordova", "plugin", "add", "device"], function () {
                 expect(cordova.raw.plugin).toHaveBeenCalledWith(
-                    "remove",
+                    "add",
                     ["device"],
                     jasmine.any(Object)
                 );
                 var opts = cordova.raw.plugin.calls.argsFor(0)[2];
-                expect(opts.save).toBe(false);
+                expect(opts.fetch).toBe(true);
                 done();
             });
         });
 
-        it("Test #018 : autosave is default and will pass save:true", function (done) {
+        it("Test #021 : (remove) fetch is true by default and will pass fetch:true", function (done) {
             cli(["node", "cordova", "plugin", "remove", "device"], function () {
                 expect(cordova.raw.plugin).toHaveBeenCalledWith(
                     "remove",
@@ -246,25 +272,12 @@ describe("cordova cli", function () {
                     jasmine.any(Object)
                 );
                 var opts = cordova.raw.plugin.calls.argsFor(0)[2];
-                expect(opts.save).toBe(true);
+                expect(opts.fetch).toBe(true);
                 done();
             });
         });
 
-        it("Test #036 : (remove) fetch is true by default and will pass fetch:true", function (done) {
-            cli(["node", "cordova", "plugin", "remove", "device"], function () {
-                expect(cordova.raw.plugin).toHaveBeenCalledWith(
-                    "remove",
-                    ["device"],
-                    jasmine.any(Object)
-                );
-                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
-                expect(opts.save).toBe(true);
-                done();
-            });
-        });
-
-        it("Test #037 : (remove) will pass fetch:false", function (done) {
+        it("Test #022 : (remove) will pass fetch:false", function (done) {
             cli(["node", "cordova", "plugin", "remove", "device", "--nofetch"], function () {
                 expect(cordova.raw.plugin).toHaveBeenCalledWith(
                     "remove",
@@ -279,7 +292,7 @@ describe("cordova cli", function () {
     });
     
     describe("telemetry", function() {
-       it("Test#019 : skips prompt when user runs 'cordova telemetry X'", function(done) {
+       it("Test#023 : skips prompt when user runs 'cordova telemetry X'", function(done) {
            var wasPromptShown = false;
            spyOn(telemetry, "showPrompt").and.callFake(function () {
                wasPromptShown = true;
@@ -293,7 +306,7 @@ describe("cordova cli", function () {
            });         
        });
        
-       it("Test#020 : is NOT collected when user runs 'cordova telemetry on' while NOT opted-in", function(done) {
+       it("Test#024 : is NOT collected when user runs 'cordova telemetry on' while NOT opted-in", function(done) {
            spyOn(telemetry, "isOptedIn").and.returnValue(false);
            spyOn(telemetry, "isCI").and.returnValue(false);
            
@@ -305,7 +318,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#021 : is collected when user runs 'cordova telemetry off' while opted-in", function(done) {
+       it("Test#025 : is collected when user runs 'cordova telemetry off' while opted-in", function(done) {
            spyOn(telemetry, "isOptedIn").and.returnValue(true);
            spyOn(telemetry, "isCI").and.returnValue(false);
            
@@ -317,7 +330,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#022 : tracks platforms/plugins subcommands", function(done) {
+       it("Test#026 : tracks platforms/plugins subcommands", function(done) {
            spyOn(telemetry, "isOptedIn").and.returnValue(true);
            spyOn(telemetry, "isCI").and.returnValue(false);
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
@@ -331,7 +344,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#023 : shows prompt if user neither opted in or out yet", function(done) {
+       it("Test#027 : shows prompt if user neither opted in or out yet", function(done) {
            spyOn(cordova.raw, "prepare").and.returnValue(Q());
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(false);
            
@@ -347,7 +360,7 @@ describe("cordova cli", function () {
 
        // ToDO: Figure out a way to modify default timeout
        // ... Timeout overriding isn't working anymore due to a bug with jasmine-node
-       xit("Test#024 : opts-out if prompt times out AND it tracks opt-out", function(done) {
+       xit("Test#028 : opts-out if prompt times out AND it tracks opt-out", function(done) {
            // Remove any optOut settings that might have been saved
            // ... and force prompt to be shown
            telemetry.clear();
@@ -362,7 +375,7 @@ describe("cordova cli", function () {
            });
        }/*, 45000*/);
        
-       it("Test#025 : is NOT collected in CI environments and doesn't prompt", function(done) {
+       it("Test#029 : is NOT collected in CI environments and doesn't prompt", function(done) {
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
            spyOn(telemetry, "isOptedIn").and.returnValue(true);
            spyOn(telemetry, "isCI").and.returnValue(true);
@@ -377,7 +390,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#026 : is NOT collected when --no-telemetry flag found and doesn't prompt", function(done) {
+       it("Test#030 : is NOT collected when --no-telemetry flag found and doesn't prompt", function(done) {
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(false);
            spyOn(telemetry, "isOptedIn").and.returnValue(true);
            spyOn(telemetry, "isCI").and.returnValue(false);
@@ -392,7 +405,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#027 : is NOT collected if user opted out", function(done) {
+       it("Test#031 : is NOT collected if user opted out", function(done) {
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
            spyOn(telemetry, "isOptedIn").and.returnValue(false);
            spyOn(telemetry, "isCI").and.returnValue(false);
@@ -407,7 +420,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#028 : is collected if user opted in", function(done) {
+       it("Test#032 : is collected if user opted in", function(done) {
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
            spyOn(telemetry, "isOptedIn").and.returnValue(true);
            spyOn(telemetry, "isCI").and.returnValue(false);
@@ -422,7 +435,7 @@ describe("cordova cli", function () {
            });
        });
        
-       it("Test#029 : track opt-out that happened via 'cordova telemetry off' even if user is NOT opted-in ", function(done) {
+       it("Test#033 : track opt-out that happened via 'cordova telemetry off' even if user is NOT opted-in ", function(done) {
            spyOn(telemetry, "isCI").and.returnValue(false);
            spyOn(telemetry, "isOptedIn").and.returnValue(false); // same as calling `telemetry.turnOff();`
            spyOn(telemetry, "hasUserOptedInOrOut").and.returnValue(true);
@@ -444,7 +457,7 @@ describe("cordova cli", function () {
             spyOn(cordova.raw, "platform").and.returnValue(Q());
         });
 
-        it("Test #030 : autosave is the default setting for platform add", function (done) {
+        it("Test #034 : (add) autosave is the default setting for platform add", function (done) {
             cli(["node", "cordova", "platform", "add", "ios"], function () {
                 expect(cordova.raw.platform).toHaveBeenCalledWith(
                     "add",
@@ -457,7 +470,7 @@ describe("cordova cli", function () {
             });
         });
 
-        it("Test #031 : platform is not saved when --nosave is passed in", function (done) {
+        it("Test #035 : (add) platform is not saved when --nosave is passed in", function (done) {
             cli(["node", "cordova", "platform", "add", "ios", "--nosave"], function () {
                 expect(cordova.raw.platform).toHaveBeenCalledWith(
                     "add",
@@ -470,7 +483,7 @@ describe("cordova cli", function () {
             });
         });
 
-        it("Test #032 : autosave is the default setting for platform remove", function (done) {
+        it("Test #036 : (remove) autosave is the default setting for platform remove", function (done) {
             cli(["node", "cordova", "platform", "remove", "ios"], function () {
                 expect(cordova.raw.platform).toHaveBeenCalledWith(
                     "remove",
@@ -483,7 +496,7 @@ describe("cordova cli", function () {
             });
         });
 
-        it("Test #033 : platform is not removed when --nosave is passed in", function (done) {
+        it("Test #037 : (remove) platform is not removed when --nosave is passed in", function (done) {
             cli(["node", "cordova", "platform", "remove", "ios", "--nosave"], function () {
                 expect(cordova.raw.platform).toHaveBeenCalledWith(
                     "remove",

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -202,6 +202,32 @@ describe("cordova cli", function () {
         it("Test #017 : will pass save:false", function (done) {
             cli(["node", "cordova", "plugin", "remove", "device", "--nosave"], function () {
                 expect(cordova.raw.plugin).toHaveBeenCalledWith(
+                    "add",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
+                expect(opts.save).toBe(false);
+                done();
+            });
+        });
+
+        it("Test #034 : (add) will pass fetch:false", function (done) {
+            cli(["node", "cordova", "plugin", "add", "device", "--nofetch"], function () {
+              expect(cordova.raw.plugin).toHaveBeenCalledWith(
+                  "add",
+                  ["device"],
+                  jasmine.any(Object)
+              );
+              var opts = cordova.raw.plugin.calls.argsFor(0)[2];
+              expect(opts.fetch).toBe(false);
+              done();
+            });
+        });
+
+        it("Test #035 : (add) fetch is true by default and will pass fetch:true", function (done) {
+            cli(["node", "cordova", "plugin", "add", "device"], function () {
+                expect(cordova.raw.plugin).toHaveBeenCalledWith(
                     "remove",
                     ["device"],
                     jasmine.any(Object)
@@ -224,8 +250,34 @@ describe("cordova cli", function () {
                 done();
             });
         });
-    }); 
 
+        it("Test #036 : (remove) fetch is true by default and will pass fetch:true", function (done) {
+            cli(["node", "cordova", "plugin", "remove", "device"], function () {
+                expect(cordova.raw.plugin).toHaveBeenCalledWith(
+                    "remove",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
+                expect(opts.save).toBe(true);
+                done();
+            });
+        });
+
+        it("Test #037 : (remove) will pass fetch:false", function (done) {
+            cli(["node", "cordova", "plugin", "remove", "device", "--nofetch"], function () {
+                expect(cordova.raw.plugin).toHaveBeenCalledWith(
+                    "remove",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.plugin.calls.argsFor(0)[2];
+                expect(opts.fetch).toBe(false);
+                done();
+            });
+        });
+    });
+    
     describe("telemetry", function() {
        it("Test#019 : skips prompt when user runs 'cordova telemetry X'", function(done) {
            var wasPromptShown = false;
@@ -444,7 +496,7 @@ describe("cordova cli", function () {
             });
         });
 
-        it("Test #036 : will pass fetch:false", function (done) {
+        it("Test #038 : (add) will pass fetch:false", function (done) {
             cli(["node", "cordova", "platform", "add", "device", "--nofetch"], function () {
               expect(cordova.raw.platform).toHaveBeenCalledWith(
                   "add",
@@ -457,7 +509,7 @@ describe("cordova cli", function () {
             });
         });
 
-        it("Test #037 : fetch is true by default and will pass fetch:true", function (done) {
+        it("Test #039 : (add) fetch is true by default and will pass fetch:true", function (done) {
             cli(["node", "cordova", "platform", "add", "device"], function () {
                 expect(cordova.raw.platform).toHaveBeenCalledWith(
                     "add",
@@ -466,6 +518,32 @@ describe("cordova cli", function () {
                 );
                 var opts = cordova.raw.platform.calls.argsFor(0)[2];
                 expect(opts.fetch).toBe(true);
+                done();
+            });
+        });
+
+        it("Test #040 : (remove) fetch is true by default and will pass fetch:true", function (done) {
+            cli(["node", "cordova", "platform", "remove", "device"], function () {
+                expect(cordova.raw.platform).toHaveBeenCalledWith(
+                    "remove",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.platform.calls.argsFor(0)[2];
+                expect(opts.fetch).toBe(true);
+                done();
+            });
+        });
+
+        it("Test #041 : (remove) will pass fetch:false", function (done) {
+            cli(["node", "cordova", "platform", "remove", "device", "--nofetch"], function () {
+                expect(cordova.raw.platform).toHaveBeenCalledWith(
+                    "remove",
+                    ["device"],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.raw.platform.calls.argsFor(0)[2];
+                expect(opts.fetch).toBe(false);
                 done();
             });
         });

--- a/src/cli.js
+++ b/src/cli.js
@@ -398,6 +398,7 @@ function cli(inputArgs) {
             args.save = false;
         } else {
             args.save = true;
+        }
 
         var download_opts = { searchpath : args.searchpath
                             , noregistry : args.noregistry
@@ -409,59 +410,58 @@ function cli(inputArgs) {
                             , save: args.save
                             , shrinkwrap: args.shrinkwrap || false
                             , force: args.force || false
-
         };
         return cordova.raw[cmd](subcommand, targets, download_opts);
     }
 }
 
- function create(undashed, args) {
-        var cfg;            // Create config
-        var customWww;      // Template path
-        var wwwCfg;         // Template config
+function create(undashed, args) {
+    var cfg;            // Create config
+    var customWww;      // Template path
+    var wwwCfg;         // Template config
 
-        // If we got a fourth parameter, consider it to be JSON to init the config.
-        if (undashed[4])
-            cfg = JSON.parse(undashed[4]);
-        else
-            cfg = {};
+    // If we got a fourth parameter, consider it to be JSON to init the config.
+    if (undashed[4])
+        cfg = JSON.parse(undashed[4]);
+    else
+        cfg = {};
 
-        customWww = args['copy-from'] || args['link-to'] || args.template;
+    customWww = args['copy-from'] || args['link-to'] || args.template;
 
-        if (customWww) {
-            if (!args.template && !args['copy-from'] && customWww.indexOf('http') === 0) {
-                throw new CordovaError(
-                    'Only local paths for custom www assets are supported for linking' + customWww
-                );
-            }
-
-            // Resolve tilda
-            if (customWww.substr(0,1) === '~')
-                customWww = path.join(process.env.HOME,  customWww.substr(1));
-
-            wwwCfg = {
-                url: customWww,
-                template: false,
-                link: false
-            };
-
-            if (args['link-to']) {
-                wwwCfg.link = true;
-            }
-            if (args.template) {
-                wwwCfg.template = true;
-            } else if (args['copy-from']) {
-                logger.warn('Warning: --copy-from option is being deprecated. Consider using --template instead.');
-                wwwCfg.template = true;
-            }
-
-            cfg.lib = cfg.lib || {};
-            cfg.lib.www = wwwCfg;
+    if (customWww) {
+        if (!args.template && !args['copy-from'] && customWww.indexOf('http') === 0) {
+            throw new CordovaError(
+                'Only local paths for custom www assets are supported for linking' + customWww
+            );
         }
-        return cordova.raw.create( undashed[1]  // dir to create the project in
-            , undashed[2]  // App id
-            , undashed[3]  // App name
-            , cfg
-            , events || undefined
-        );
+
+        // Resolve tilda
+        if (customWww.substr(0,1) === '~')
+            customWww = path.join(process.env.HOME,  customWww.substr(1));
+
+        wwwCfg = {
+            url: customWww,
+            template: false,
+            link: false
+        };
+
+        if (args['link-to']) {
+            wwwCfg.link = true;
+        }
+        if (args.template) {
+            wwwCfg.template = true;
+        } else if (args['copy-from']) {
+            logger.warn('Warning: --copy-from option is being deprecated. Consider using --template instead.');
+            wwwCfg.template = true;
+        }
+
+        cfg.lib = cfg.lib || {};
+        cfg.lib.www = wwwCfg;
     }
+    return cordova.raw.create( undashed[1]  // dir to create the project in
+        , undashed[2]  // App id
+        , undashed[3]  // App name
+        , cfg
+        , events || undefined
+    );
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -302,13 +302,19 @@ function cli(inputArgs) {
         throw new CordovaError(msg2);
     }
 
+    if (args.nofetch) {
+        args.fetch = false;
+    } else {
+        args.fetch = true;
+    }
+
     var opts = {
         platforms: [],
         options: [],
         verbose: args.verbose || false,
         silent: args.silent || false,
         browserify: args.browserify || false,
-        fetch: args.fetch || false,
+        fetch: args.fetch,
         nohooks: args.nohooks || [],
         searchpath : args.searchpath
     };
@@ -325,7 +331,6 @@ function cli(inputArgs) {
         if (cmd === 'run' && args.list && cordova.raw.targets) {
             return cordova.raw.targets.call(null, opts);
         }
-
         return cordova.raw[cmd].call(null, opts);
 
     } else if (cmd === 'requirements') {
@@ -393,18 +398,18 @@ function cli(inputArgs) {
             args.save = false;
         } else {
             args.save = true;
-        }
 
         var download_opts = { searchpath : args.searchpath
                             , noregistry : args.noregistry
                             , nohooks : args.nohooks
                             , cli_variables : cli_vars
                             , browserify: args.browserify || false
-                            , fetch: args.fetch || false
+                            , fetch: args.fetch
                             , link: args.link || false
                             , save: args.save
                             , shrinkwrap: args.shrinkwrap || false
                             , force: args.force || false
+
         };
         return cordova.raw[cmd](subcommand, targets, download_opts);
     }


### PR DESCRIPTION
Not ready for review yet :)
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Fetch is true by default and --nofetch flag is added. Tests are updated and created to test the --nofetch flag and if fetch is the default. .txt files also updated.

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
