### PR TITLE
CB-13353 : added save-exact option

### DIFF
--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -265,6 +265,19 @@ describe('cordova cli', function () {
             });
         });
 
+        it('(add) will pass save-exact:true', function (done) {
+            cli(['node', 'cordova', 'plugin', 'add', 'device', '--save-exact'], function () {
+                expect(cordova.plugin).toHaveBeenCalledWith(
+                    'add',
+                    ['device'],
+                    jasmine.any(Object)
+                );
+                var opts = cordova.plugin.calls.argsFor(0)[2];
+                expect(opts.save_exact).toBe(true);
+                done();
+            });
+        });
+
         it('Test #021 : (remove) fetch is true by default and will pass fetch:true', function (done) {
             cli(['node', 'cordova', 'plugin', 'remove', 'device'], function () {
                 expect(cordova.plugin).toHaveBeenCalledWith(

--- a/src/cli.js
+++ b/src/cli.js
@@ -47,6 +47,7 @@ var knownOpts = {
     'variable': Array,
     'link': Boolean,
     'force': Boolean,
+    'save-exact': Boolean,
     // Flags to be passed to `cordova build/run/emulate`
     'debug': Boolean,
     'release': Boolean,
@@ -466,6 +467,11 @@ function cli (inputArgs) {
             args.searchpath = conf.get('searchpath');
         }
 
+        if (args['save-exact'] === undefined) {
+            // User explicitly did not pass in save-exact
+            args['save-exact'] = conf.get('save-exact');
+        }
+
         var download_opts = { searchpath: args.searchpath,
             noregistry: args.noregistry,
             nohooks: args.nohooks,
@@ -474,6 +480,7 @@ function cli (inputArgs) {
             fetch: args.fetch,
             link: args.link || false,
             save: args.save,
+            save_exact: args['save-exact'] || false,
             shrinkwrap: args.shrinkwrap || false,
             force: args.force || false
         };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Added save-exact option

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
