### PR TITLE
Use native Promises instead of Q

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "editor": "1.0.0",
     "insight": "0.8.2",
     "nopt": "3.0.1",
-    "q": "1.0.1",
     "update-notifier": "0.5.0"
   },
   "devDependencies": {

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -17,7 +17,6 @@
 
 var rewire = require('rewire');
 var cli = rewire('../src/cli');
-var Q = require('q');
 var cordova_lib = require('cordova-lib');
 var events = cordova_lib.events;
 var cordova = cordova_lib.cordova;
@@ -84,7 +83,7 @@ describe('cordova cli', function () {
 
     describe('Test#004 : project commands other than plugin and platform', function () {
         beforeEach(function () {
-            spyOn(cordova, 'build').and.returnValue(Q());
+            spyOn(cordova, 'build').and.returnValue(Promise.resolve());
         });
 
         it('Test#005 : will call command with all arguments passed through', function (done) {
@@ -132,7 +131,7 @@ describe('cordova cli', function () {
 
     describe('create', function () {
         beforeEach(function () {
-            spyOn(cordova, 'create').and.returnValue(Q());
+            spyOn(cordova, 'create').and.returnValue(Promise.resolve());
         });
 
         it('Test#011 : calls cordova create', function (done) {
@@ -145,7 +144,7 @@ describe('cordova cli', function () {
 
     describe('plugin', function () {
         beforeEach(function () {
-            spyOn(cordova, 'plugin').and.returnValue(Q());
+            spyOn(cordova, 'plugin').and.returnValue(Promise.resolve());
         });
 
         it('Test#012 : will pass variables', function (done) {
@@ -359,7 +358,7 @@ describe('cordova cli', function () {
             spyOn(telemetry, 'isOptedIn').and.returnValue(true);
             spyOn(telemetry, 'isCI').and.returnValue(false);
             spyOn(telemetry, 'hasUserOptedInOrOut').and.returnValue(true);
-            spyOn(cordova, 'platform').and.returnValue(Q());
+            spyOn(cordova, 'platform').and.returnValue(Promise.resolve());
             spyOn(telemetry, 'track');
 
             cli(['node', 'cordova', 'platform', 'add', 'ios'], function () {
@@ -369,11 +368,11 @@ describe('cordova cli', function () {
         });
 
         it('Test#027 : shows prompt if user neither opted in or out yet', function (done) {
-            spyOn(cordova, 'prepare').and.returnValue(Q());
+            spyOn(cordova, 'prepare').and.returnValue(Promise.resolve());
             spyOn(telemetry, 'hasUserOptedInOrOut').and.returnValue(false);
             spyOn(telemetry, 'isCI').and.returnValue(false);
             spyOn(telemetry, 'isNoTelemetryFlag').and.returnValue(false);
-            spyOn(telemetry, 'showPrompt').and.returnValue(Q(false));
+            spyOn(telemetry, 'showPrompt').and.returnValue(Promise.resolve(false));
 
             cli(['node', 'cordova', 'prepare'], function () {
                 expect(telemetry.showPrompt).toHaveBeenCalled();
@@ -491,7 +490,7 @@ describe('raw', function () {
 describe('platform', function () {
 
     beforeEach(function () {
-        spyOn(cordova, 'platform').and.returnValue(Q());
+        spyOn(cordova, 'platform').and.returnValue(Promise.resolve());
         logger.setLevel('error');
     });
 

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -18,8 +18,6 @@
 // For further details on telemetry, see:
 // https://github.com/cordova/cordova-discuss/pull/43
 
-var Q = require('q');
-
 // Google Analytics tracking code
 var GA_TRACKING_CODE = 'UA-64283057-7';
 
@@ -34,25 +32,22 @@ var insight = new Insight({
  * Returns true if the user opted in, and false otherwise
  */
 function showPrompt () {
-
-    var deferred = Q.defer();
-
-    var msg = 'May Cordova anonymously report usage statistics to improve the tool over time?';
-    insight._permissionTimeout = module.exports.timeoutInSecs || 30;
-    insight.askPermission(msg, function (unused, optIn) {
-        var EOL = require('os').EOL;
-        if (optIn) {
-            console.log(EOL + 'Thanks for opting into telemetry to help us improve cordova.');
-            module.exports.track('telemetry', 'on', 'via-cli-prompt-choice', 'successful');
-        } else {
-            console.log(EOL + 'You have been opted out of telemetry. To change this, run: cordova telemetry on.');
-            // Always track telemetry opt-outs! (whether opted-in or opted-out)
-            module.exports.track('telemetry', 'off', 'via-cli-prompt-choice', 'successful');
-        }
-        deferred.resolve(optIn);
+    return new Promise(function (resolve, reject) {
+        var msg = 'May Cordova anonymously report usage statistics to improve the tool over time?';
+        insight._permissionTimeout = module.exports.timeoutInSecs || 30;
+        insight.askPermission(msg, function (unused, optIn) {
+            var EOL = require('os').EOL;
+            if (optIn) {
+                console.log(EOL + 'Thanks for opting into telemetry to help us improve cordova.');
+                module.exports.track('telemetry', 'on', 'via-cli-prompt-choice', 'successful');
+            } else {
+                console.log(EOL + 'You have been opted out of telemetry. To change this, run: cordova telemetry on.');
+                // Always track telemetry opt-outs! (whether opted-in or opted-out)
+                module.exports.track('telemetry', 'off', 'via-cli-prompt-choice', 'successful');
+            }
+            resolve(optIn);
+        });
     });
-
-    return deferred.promise;
 }
 
 function track () {


### PR DESCRIPTION
Node 4.x (which we're dropping in April 2018 as I recall) has native Promises, so let's use them.