### PR TITLE
CB-13772: print version numbers correctly in "cordova requirements"

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -397,7 +397,7 @@ function cli (inputArgs) {
                     platformCheck.forEach(function (checkItem) {
                         var checkSummary = checkItem.name + ': ' +
                             (checkItem.installed ? 'installed ' : 'not installed ') +
-                            (checkItem.metadata.version || '');
+                            (checkItem.installed ? checkItem.metadata.version.version || checkItem.metadata.version : '');
                         events.emit('log', checkSummary);
                         if (!checkItem.installed) {
                             someChecksFailed = true;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### What does this PR do?
This PR fixes the bug where `cordova requirements` did not print out version numbers correctly.
Previously, it would print something like `ios-deploy: installed [object Object]`. Now it prints `ios-deploy: installed 1.9.2`.

### What testing has been done on this change?
This was a one line fix so none of the automated testing was run. I manually verified that the fix prints the version numbers correctly for the Android and iOS requirements.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
Issue reported here: https://issues.apache.org/jira/browse/CB-13772
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
(No additional testing applicable)
