### PR TITLE
CB-12242 : Use yarn instead of npm

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -453,6 +453,12 @@ function cli (inputArgs) {
             args.production = true;
         }
 
+        if (args.yarn) {
+            args.manager = 'yarn';
+        } else {
+            args.manager = 'npm';
+        }
+
         if (args.save === undefined) {
             // User explicitly did not pass in save
             args.save = conf.get('autosave');
@@ -486,7 +492,8 @@ function cli (inputArgs) {
             save_exact: args['save-exact'] || false,
             shrinkwrap: args.shrinkwrap || false,
             force: args.force || false,
-            production: args.production
+            production: args.production,
+            manager: args.manager
         };
         return cordova[cmd](subcommand, targets, download_opts);
     }


### PR DESCRIPTION
### Platforms affected

All

### What does this PR do?

Allows user to select his package manager used by cordova-fetch, possible values are "npm" or "yarn", defaulting to "npm"

### What testing has been done on this change?

None, since we're just adding cordova arguments here

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
