### PR TITLE
Deprecate 'cordova plugin search' command docs

### DIFF
--- a/doc/plugin.txt
+++ b/doc/plugin.txt
@@ -35,8 +35,6 @@ Manage project plugins
     list .............................. List currently installed plugins
     save .............................. Saves the information for all currently added plugins to config.xml
 
-    search [<keyword>] [...] .......... Search http://plugins.cordova.io for plugins matching the keywords
-
 Syntax
     <plugin-spec> : <pluginID>[@<version>]|<directory>|<url>[#<commit-ish>][:subdir]
 

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -313,7 +313,6 @@ cordova {plugin | plugins} [
     add <plugin-spec> [..] {--searchpath=<directory> | --noregistry | --link | --save | --browserify | --force} |
     {remove | rm} {<pluginid> | <name>} --save |
     {list | ls} |
-    search [<keyword>] |
     save |
 ]
 ```
@@ -330,7 +329,6 @@ cordova {plugin | plugins} [
 | remove `<pluginid>|<name>` [...]| | Remove plugins with the given IDs/name.
 |       |--nosave                 | Do NOT remove the specified plugin from config.xml or package.json
 |list                           |  | List currently installed plugins
-|search `[<keyword>]` [...]     |  | Search http://plugins.cordova.io for plugins matching the keywords
 |save                           |  | Save `<plugin-spec>` of all plugins currently added to the project
 
 ### Plugin-spec


### PR DESCRIPTION
### Platforms affected
none

### What does this PR do?
Remove (deprecate) `cordova plugin search` related help docs.

Related to PR: https://github.com/apache/cordova-lib/pull/671

### What testing has been done on this change?
- [x] `npm test`
