### PR TITLE
Don't do 'nightly testing' & simplify CI configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,13 @@
 language: node_js
-sudo: false
+
+# Performance optimization
 git:
   depth: 10
+cache:
+  directories:
+    - $HOME/.npm
+
 node_js:
   - "6"
   - "8"
   - "10"
-
-before_install:
-  - npm cache clean -f
-  - npm install -g npm@2
-
-# getting cordova tools dependencies from github
-# to make sure we're using their latest versions
-install:
-  - cd ..
-  - git clone https://github.com/apache/cordova-js --depth 10
-  - cd cordova-js
-  - npm install
-  - npm link
-  - cd ..
-  - git clone https://github.com/apache/cordova-lib --depth 10
-  - cd cordova-lib/
-  - npm install
-  - npm link cordova-js
-  - npm link
-  - cd ../cordova-cli
-  - npm link cordova-lib
-  - npm install
-  # # Workaround for npm/npm#10343
-  # - npm install
-  # - (cd ../cordova-js && npm install && npm link)
-  # - (cd ../cordova-lib/cordova-lib && npm install && npm link ../../cordova-js)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,45 +1,25 @@
-# appveyor file
 # http://www.appveyor.com/docs/appveyor-yml
+
+# Performance optimization
+shallow_clone: true
+cache:
+  - '%APPDATA%\npm-cache'
 
 environment:
   matrix:
-  - nodejs_version: "6"
-  - nodejs_version: "8"
-  - nodejs_version: "10"
+    - nodejs_version: "6"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
 
-# getting cordova tools dependencies from github
-# to make sure we're using their latest versions
 install:
-  - npm cache clean -f
-  - npm install -g npm@2
   - ps: Install-Product node $env:nodejs_version
-  - cd ..
-  - git clone https://github.com/apache/cordova-js --depth 10
-  - cd cordova-js
   - npm install
-  - npm link
-  - cd ..
-  - git clone https://github.com/apache/cordova-lib --depth 10
-  - cd cordova-lib
-  - npm install
-  - npm link cordova-js
-  - npm link
-  - cd ../cordova-cli
-  - npm link cordova-lib
-  - npm install
-  # # Workaround for npm/npm#10343
-  # - npm install
-  # - cd ../cordova-js
-  # - npm install
-  # - npm link
-  # - cd ../cordova-lib/cordova-lib
-  # - npm install
-  # - npm link ../../cordova-js
-  # - cd ../../cordova-cli
 
 build: off
 
 test_script:
+  # Workaround for https://github.com/appveyor/ci/issues/2420
+  - set "PATH=%PATH%;C:\Program Files\Git\mingw64\libexec\git-core"
   - node --version
   - npm --version
   - npm test


### PR DESCRIPTION
Until now, the CI test of this repo used the master versions of several dependencies instead of the specified versions.

I think testing the latest master versions together is already done by our nightly builds. And given the relatively low commit frequency of this repo, tests are triggered too seldom to achieve the desired effect.

This PR returns the CI configs to a normal state and cleans them up.