### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "update-notifier": "0.5.0"
   },
   "devDependencies": {
-    "eslint": "^4.0.0",
-    "eslint-config-semistandard": "^11.0.0",
-    "eslint-config-standard": "^10.2.1",
+    "eslint": "^5.4.0",
+    "eslint-config-semistandard": "^12.0.1",
+    "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.3.0",
-    "eslint-plugin-node": "^5.0.0",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.1",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^4.0.0",
+    "eslint-plugin-standard": "^4.0.0",
     "istanbul": "^0.4.5",
     "jasmine": "^2.5.2",
     "rewire": "^2.5.2"

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "cli"
   ],
   "dependencies": {
-    "configstore": "2.1.0",
+    "configstore": "^4.0.0",
     "cordova-common": "^2.2.0",
     "cordova-lib": "8.0.0",
     "editor": "1.0.0",
     "insight": "0.8.4",
     "loud-rejection": "^1.6.0",
-    "nopt": "3.0.1",
-    "update-notifier": "0.5.0"
+    "nopt": "^4.0.1",
+    "update-notifier": "^2.5.0"
   },
   "devDependencies": {
     "eslint": "^5.4.0",
@@ -48,8 +48,8 @@
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-standard": "^4.0.0",
     "istanbul": "^0.4.5",
-    "jasmine": "^2.5.2",
-    "rewire": "^2.5.2"
+    "jasmine": "^3.1.0",
+    "rewire": "^4.0.1"
   },
   "author": "Anis Kadri",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cordova-common": "^2.2.0",
     "cordova-lib": "8.0.0",
     "editor": "1.0.0",
-    "insight": "0.8.4",
+    "insight": "^0.10.1",
     "loud-rejection": "^1.6.0",
     "nopt": "^4.0.1",
     "update-notifier": "^2.5.0"

--- a/src/cli.js
+++ b/src/cli.js
@@ -76,7 +76,7 @@ var shortHands = {
 function checkForUpdates () {
     try {
         // Checks for available update and returns an instance
-        var notifier = updateNotifier({pkg: pkg});
+        var notifier = updateNotifier({ pkg: pkg });
 
         if (notifier.update &&
            notifier.update.latest !== pkg.version) {


### PR DESCRIPTION
- No update to Jasmine 3.2 because of https://github.com/apache/cordova-lib/pull/639
- Updated `insight` to resolve #300 
  - To resolve #300, updating to 0.9.0 would have sufficed.
  - Because of yeoman/insight@dae6dd4 users will be asked again whether they want data to be collected. However, with the upcoming major release, I think users could see why they get asked permission again.