### PR TITLE
Check if bin/cordova is working on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,4 +23,5 @@ test_script:
   - set "PATH=%PATH%;C:\Program Files\Git\mingw64\libexec\git-core"
   - node --version
   - npm --version
+  - bin\cordova --version
   - npm test


### PR DESCRIPTION
Avoid issues such as #339 (minor release broken on Node.js 4) in the future

NOTES:
- This proposal is expected to fail on AppVeyor on Node.js 4 in 8.1.x until #339 is resolved.
- I think this change should be included on both 8.1.x and master.