### PR TITLE
GH-706 cordova-lib@8.1.1 dependency update (8.x only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "configstore": "^3.1.2",
     "cordova-common": "^2.2.0",
-    "cordova-lib": "8.1.0",
+    "cordova-lib": "8.1.1",
     "editor": "1.0.0",
     "insight": "^0.8.4",
     "loud-rejection": "^1.6.0",


### PR DESCRIPTION
according to procedure documented in:
- <https://github.com/apache/cordova-coho/blob/master/docs/tools-release-process.md#update-release-notes--version>