### PR TITLE
update readme.md with buildConfig detail

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -497,7 +497,7 @@ cordova run [<platform> [...]]
 | --device    | Deploy to a device
 | --emulator  | Deploy to an emulator
 | --target    | Deploy to a specific target emulator/device. Use `--list` to display target options
-| --buildConfig=`<configFile>` | Default: build.json in cordova root directory. <br/> Use the specified build configuration file. `build.json` file is used to specify paramaters to customize the app build process esecially related to signing the package.
+| --buildConfig=`<configFile>` | Default: build.json in cordova root directory. <br/> Use the specified build configuration file. `build.json` file is used to specify paramaters to customize the app build process esecially related to signing the package.<br/> Use `~` to target to `HOME` enviroment variable.
 | `<platformOpts>` | To provide platform specific options, you must include them after `--` separator. Review platform guide docs for more details.
 
 ### Examples


### PR DESCRIPTION
### Platforms affected
android, ios, browser

### What does this PR do?
just update readme to clarify that have `~` can realate to `HOME` path enviroment variable

### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
