### PR TITLE
Cordova CLI Release Preparation (Cordova 9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "configstore": "^4.0.0",
     "cordova-common": "^3.1.0",
-    "cordova-lib": "8.0.0",
+    "cordova-lib": "^9.0.0",
     "editor": "1.0.0",
     "insight": "^0.10.1",
     "loud-rejection": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "configstore": "^4.0.0",
     "cordova-common": "^3.1.0",
     "cordova-lib": "^9.0.0",
-    "editor": "1.0.0",
+    "editor": "^1.0.0",
     "insight": "^0.10.1",
     "loud-rejection": "^1.6.0",
     "nopt": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "update-notifier": "^2.5.0"
   },
   "devDependencies": {
-    "eslint": "^5.4.0",
+    "eslint": "^5.15.2",
     "eslint-config-semistandard": "^12.0.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cordova-lib": "^9.0.0",
     "editor": "^1.0.0",
     "insight": "^0.10.1",
-    "loud-rejection": "^1.6.0",
+    "loud-rejection": "^2.0.0",
     "nopt": "^4.0.1",
     "update-notifier": "^2.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^8.0.1",
-    "eslint-plugin-promise": "^4.0.0",
+    "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "istanbul": "^0.4.5",
     "jasmine": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "eslint": "^5.15.2",
     "eslint-config-semistandard": "^13.0.0",
-    "eslint-config-standard": "^11.0.0",
+    "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-promise": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-config-semistandard": "^13.0.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-standard": "^4.0.0",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "istanbul": "^0.4.5",
-    "jasmine": "^3.1.0",
+    "jasmine": "^3.3.1",
     "rewire": "^4.0.1"
   },
   "author": "Anis Kadri",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint": "^5.15.2",
     "eslint-config-semistandard": "^13.0.0",
     "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-import": "^2.3.0",
+    "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-standard": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "configstore": "^4.0.0",
-    "cordova-common": "^2.2.0",
+    "cordova-common": "^3.1.0",
     "cordova-lib": "8.0.0",
     "editor": "1.0.0",
     "insight": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "eslint": "^5.15.2",
-    "eslint-config-semistandard": "^12.0.1",
+    "eslint-config-semistandard": "^13.0.0",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-node": "^7.0.1",

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -18,6 +18,22 @@
 const fs = require('fs');
 const path = require('path');
 const rewire = require('rewire');
+/*
+    After Cordova-Common 3.1.0, logger[level] property becomes not writable.
+    Therefore we re-define addLevel function here to use SpyOn logger[level]
+*/
+const CordovaLogger = require('cordova-common').CordovaLogger;
+CordovaLogger.prototype.addLevel = function (level, severity, color) {
+    this.levels[level] = severity;
+    if (color) {
+        this.colors[level] = color;
+    }
+    // Define own method with corresponding name
+    if (!this[level]) {
+        this[level] = this.log.bind(this, level);
+    }
+    return this;
+};
 const { events, cordova } = require('cordova-lib');
 const logger = require('cordova-common').CordovaLogger.get();
 const telemetry = require('../src/telemetry');


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
Cordova 9 Release

This PR contains final preparations for the Cordova 9 release goals. 

See [Cordova 9 Release Plan](https://github.com/apache/cordova/issues/10).

- Overload method `addLevel` to continue to support test spies on `logger[level]`.

- **Bumped Dependencies**
  - `cordova-common@^3.1.0`
  - `cordova-lib@^9.0.0`
  - `editor@^1.0.0` (Added `^` only)
  - `loud-rejection@^2.0.0`
- **Bumped ESLint dependencies with correction**
  - `eslint@^5.15.2`
  - `eslint-config-semistandard@^13.0.0`
  - `eslint-config-standard@^12.0.0`
  - `eslint-plugin-import@^2.16.0`
  - `eslint-plugin-node@^8.0.1`
  - `eslint-plugin-promise@^4.0.1`
- **Updated Dev Dependencies**
  - `jasmine@^3.3.1`

### Testing
- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
