### PR TITLE
Fix config list command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -148,7 +148,7 @@ module.exports = function (inputArgs) {
     }
 
     // If "ls" is called
-    if ((isConfigCmd && inputArgs[3] === 'ls') || (inputArgs[3] === 'list')) {
+    if (isConfigCmd && (inputArgs[3] === 'ls' || inputArgs[3] === 'list')) {
         fs.readFile(conf.path, 'utf8', function (err, data) {
             if (err) {
                 logger.error(err);


### PR DESCRIPTION
The `cordova config list` command will be executed for any command with `list` as an argument, such as `cordova plugin list`. This PR fixes the if-statement to only apply to `cordova config list`.

### Platforms affected



### Motivation and Context

This behavior becomes evident due to #418:

```
$ npm install -g cordova@latest
$ rm ~/.config/configstore/cordova-config.json
$ cordova plugin list
Current working directory is not a Cordova-based project.
Error: ENOENT: no such file or directory, open '/Users/ltm/.config/configstore/cordova-config.json'
```

The error is triggered by the `config list` command which is incorrectly being executed as part of the `plugin list` command.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
