### PR TITLE
Handle output error strings

### DIFF
--- a/bin/cordova
+++ b/bin/cordova
@@ -26,7 +26,11 @@ const cli = require('../src/cli');
 
 cli(process.argv).catch(err => {
     if (!(err instanceof Error)) {
-        throw new CordovaError('Promise rejected with non-error: ' + util.inspect(err));
+        const errorOutput = typeof err === 'string'
+            ? err
+            : util.inspect(err);
+
+        throw new CordovaError('Promise rejected with non-error: ' + errorOutput);
     }
     process.exitCode = err.code || 1;
 

--- a/bin/cordova
+++ b/bin/cordova
@@ -26,10 +26,7 @@ const cli = require('../src/cli');
 
 cli(process.argv).catch(err => {
     if (!(err instanceof Error)) {
-        const errorOutput = typeof err === 'string'
-            ? err
-            : util.inspect(err);
-
+        const errorOutput = typeof err === 'string' ? err : util.inspect(err);
         throw new CordovaError('Promise rejected with non-error: ' + errorOutput);
     }
     process.exitCode = err.code || 1;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all

Host OS: at least Windows


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Properly output error strings


### Description
<!-- Describe your changes in detail -->
When command rejects with a string, it's special characters like newlines and tabs are not formatted,

Example:
```
cordova platform update cordova-ios --save

Using cordova-fetch for cordova-ios
Updating ios project...
CordovaError: Promise rejected with non-error: 'An in-place platform update is not supported. \nThe `platforms` folder is always treated as a build artifact.\nTo update your platform, you have to remove, then add your ios platform again.\nMake sure you save your plugins beforehand using `cordova plugin save`, and save a copy of the platform first if you had manual changes in it.\n\tcordova plugin save\n\tcordova platform rm ios\n\tcordova platform add ios\n'
    at cli.catch.err (xxx\node_modules\cordova\bin\cordova:29:15)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
```
After:
```
cordova platform update cordova-ios --save
Using cordova-fetch for cordova-ios
Updating ios project...
CordovaError: Promise rejected with non-error: An in-place platform update is not supported.
The `platforms` folder is always treated as a build artifact.
To update your platform, you have to remove, then add your ios platform again.
Make sure you save your plugins beforehand using `cordova plugin save`, and save a copy of the platform first if you had manual changes in it.
        cordova plugin save
        cordova platform rm ios
        cordova platform add ios

    at cli.catch.err (xxx\node_modules\cordova\bin\cordova:33:15)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
```


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
