### PR TITLE
chore: node warning on version < 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "insight": "^0.10.1",
     "loud-rejection": "^2.0.0",
     "nopt": "^4.0.1",
+    "semver": "^6.2.0",
     "update-notifier": "^2.5.0"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -29,6 +29,9 @@ var logger = require('cordova-common').CordovaLogger.get();
 var Configstore = require('configstore');
 var conf = new Configstore(pkg.name + '-config');
 var editor = require('editor');
+const semver = require('semver');
+
+const NODE_VERSION_REQUIREMENT = '>=8';
 
 var knownOpts = {
     'verbose': Boolean,
@@ -296,10 +299,9 @@ function cli (inputArgs) {
         }
     }
 
-    if (/^v0.\d+[.\d+]*/.exec(process.version)) { // matches v0.*
-        var msg1 = 'Warning: using node version ' + process.version +
-                ' which has been deprecated. Please upgrade to the latest Node.js version available (LTS version recommended).';
-        logger.warn(msg1);
+    // If the Node.js versions does not meet our requirements, it will then display warning.
+    if (!semver.satisfies(process.version, NODE_VERSION_REQUIREMENT)) {
+        logger.warn(`Warning: Node.js ${process.version} is no longer supported. Please upgrade to the latest Node.js version available (LTS version recommended).`);
     }
 
     // If there were arguments protected from nopt with a double dash, keep


### PR DESCRIPTION
### Motivation and Context
https://github.com/apache/cordova/issues/79

- To warn users if they are on an unsupported node version.
- The supported node version requirement is `>=8`.
- Cordova will continue to work as usual on an unsupported version but with a warning.

### Description
- Added `semver` dependency.
- Update the satisfactory requirement. 
  - Past checks warned when `v0.x` matched
  - New checks warn when node version does not meet requirement: `>=8`.

Example: node process on version `6.17.1` will warn users:

```
Warning: Node.js v6.17.1 is no longer supported. Please upgrade to the latest Node.js version available (LTS version recommended).
```


### Testing
- `npm t`

### Checklist
- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
