### PR TITLE
chore: node deprecation warning for <10

### DIFF
--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -507,4 +507,54 @@ describe('cordova cli', () => {
             });
         });
     });
+
+    describe('node requirement', () => {
+        it('should warn users about unsupported node version', () => {
+            cli.__set__('NODE_VERSION', 'v6.1.0');
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE1', null);
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE2', null);
+            cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
+
+            return cli(['node', 'cordova']).then(() => {
+                const errorMsg = logger.warn.calls.argsFor(1).toString();
+                expect(errorMsg).toMatch(/v6.1.0 is no longer supported./);
+            });
+        });
+
+        it('should not warn users about unsupported node version', () => {
+            cli.__set__('NODE_VERSION', 'v8.0.0');
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE1', null);
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE2', null);
+            cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
+
+            return cli(['node', 'cordova']).then(() => {
+                const errorMsg = logger.warn.calls.argsFor(1).toString();
+                expect(errorMsg).toBeFalsy();
+            });
+        });
+
+        it('should warn users about deprecated node version', () => {
+            cli.__set__('NODE_VERSION', 'v8.0.0');
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE1', '>=8');
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE2', '<10');
+            cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
+
+            return cli(['node', 'cordova']).then(() => {
+                const errorMsg = logger.warn.calls.argsFor(1).toString();
+                expect(errorMsg).toMatch(/v8.0.0 has been deprecated./);
+            });
+        });
+
+        it('should warn users about deprecated node version', () => {
+            cli.__set__('NODE_VERSION', 'v10.0.0');
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE1', '>=8');
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE2', '<10');
+            cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
+
+            return cli(['node', 'cordova']).then(() => {
+                const errorMsg = logger.warn.calls.argsFor(1).toString();
+                expect(errorMsg).toBeFalsy();
+            });
+        });
+    });
 });

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -511,8 +511,7 @@ describe('cordova cli', () => {
     describe('node requirement', () => {
         it('should warn users about unsupported node version', () => {
             cli.__set__('NODE_VERSION', 'v6.1.0');
-            cli.__set__('NODE_VERSION_DEPRECATING_RANGE1', null);
-            cli.__set__('NODE_VERSION_DEPRECATING_RANGE2', null);
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE', null);
             cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
 
             return cli(['node', 'cordova']).then(() => {
@@ -523,8 +522,7 @@ describe('cordova cli', () => {
 
         it('should not warn users about unsupported node version', () => {
             cli.__set__('NODE_VERSION', 'v8.0.0');
-            cli.__set__('NODE_VERSION_DEPRECATING_RANGE1', null);
-            cli.__set__('NODE_VERSION_DEPRECATING_RANGE2', null);
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE', null);
             cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
 
             return cli(['node', 'cordova']).then(() => {
@@ -535,8 +533,7 @@ describe('cordova cli', () => {
 
         it('should warn users about deprecated node version', () => {
             cli.__set__('NODE_VERSION', 'v8.0.0');
-            cli.__set__('NODE_VERSION_DEPRECATING_RANGE1', '>=8');
-            cli.__set__('NODE_VERSION_DEPRECATING_RANGE2', '<10');
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE', '<10');
             cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
 
             return cli(['node', 'cordova']).then(() => {
@@ -547,8 +544,7 @@ describe('cordova cli', () => {
 
         it('should warn users about deprecated node version', () => {
             cli.__set__('NODE_VERSION', 'v10.0.0');
-            cli.__set__('NODE_VERSION_DEPRECATING_RANGE1', '>=8');
-            cli.__set__('NODE_VERSION_DEPRECATING_RANGE2', '<10');
+            cli.__set__('NODE_VERSION_DEPRECATING_RANGE', '<10');
             cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
 
             return cli(['node', 'cordova']).then(() => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -35,9 +35,8 @@ const semver = require('semver');
 const NODE_VERSION = process.version;
 
 // When there is no node version in the deprecation stage, set to null or false.
-const NODE_VERSION_DEPRECATING_RANGE1 = '>=8';
-const NODE_VERSION_DEPRECATING_RANGE2 = '<10';
 const NODE_VERSION_REQUIREMENT = '>=8';
+const NODE_VERSION_DEPRECATING_RANGE = '<10';
 
 var knownOpts = {
     'verbose': Boolean,
@@ -310,7 +309,7 @@ function cli (inputArgs) {
     // If the Node.js versions does not meet our requirements or in a deprecation stage, display a warning.
     if (!semver.satisfies(NODE_VERSION, NODE_VERSION_REQUIREMENT)) {
         warningPartial = 'is no longer supported';
-    } else if (NODE_VERSION_DEPRECATING_RANGE1 && NODE_VERSION_DEPRECATING_RANGE2 && semver.satisfies(NODE_VERSION, NODE_VERSION_DEPRECATING_RANGE1) && semver.satisfies(NODE_VERSION, NODE_VERSION_DEPRECATING_RANGE2)) {
+    } else if (NODE_VERSION_DEPRECATING_RANGE && semver.satisfies(NODE_VERSION, NODE_VERSION_DEPRECATING_RANGE)) {
         warningPartial = 'has been deprecated';
     }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -309,11 +309,15 @@ function cli (inputArgs) {
     // If the Node.js versions does not meet our requirements or in a deprecation stage, display a warning.
     if (!semver.satisfies(NODE_VERSION, NODE_VERSION_REQUIREMENT)) {
         warningPartial = 'is no longer supported';
-    } else if (NODE_VERSION_DEPRECATING_RANGE && semver.satisfies(NODE_VERSION, NODE_VERSION_DEPRECATING_RANGE)) {
+    } else if (NODE_VERSION_DEPRECATING_RANGE &&
+               semver.satisfies(NODE_VERSION, NODE_VERSION_DEPRECATING_RANGE)) {
         warningPartial = 'has been deprecated';
     }
 
-    if (warningPartial) logger.warn(`Warning: Node.js ${NODE_VERSION} ${warningPartial}. Please upgrade to the latest Node.js version available (LTS version recommended).`);
+    if (warningPartial) {
+        const upgradeMsg = `Please upgrade to the latest Node.js version available (LTS version recommended).`;
+        logger.warn(`Warning: Node.js ${NODE_VERSION} ${warningPartial}. ${upgradeMsg}`);
+    }
 
     // If there were arguments protected from nopt with a double dash, keep
     // them in unparsedArgs. For example:


### PR DESCRIPTION
### Description
- Adds deprecation warning for node between `>= 8` and  `<10`
- Adds Unit Tests

### Testing
- npm t

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] I've updated the documentation if necessary
