### PR TITLE
chore: replace istanbul with nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage
+.nyc_output
 node_modules
 npm-debug.log
 temp

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ temp
 spec
 e2e
 coverage
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "cordova": "./bin/cordova"
   },
   "scripts": {
-    "test": "npm run eslint && jasmine",
+    "test": "npm run eslint && npm run cover",
     "eslint": "eslint . bin/cordova",
-    "cover": "istanbul cover --root src --print detail jasmine"
+    "cover": "nyc jasmine"
   },
   "repository": {
     "type": "git",
@@ -47,8 +47,8 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "istanbul": "^0.4.5",
     "jasmine": "^3.3.1",
+    "nyc": "^14.1.1",
     "rewire": "^4.0.1"
   },
   "author": "Anis Kadri",
@@ -150,5 +150,15 @@
       "email": "purplecabbage@gmail.com"
     }
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "nyc": {
+    "include": [
+      "bin/**",
+      "src/**"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ]
+  }
 }


### PR DESCRIPTION
### Motivation and Context

* Remove npm install warnings of a deprecated package.
* Be consistent with the packages we use in other repos.

### Description

* Remove `istanbul` package
* Add `nyc` package
* Update `.gitignore` and `.npmignore` to exclude the `.nyc_output`
* Update `npm test` to run the coverage instead of jasmine directly which produces the same results + coverage.

### Testing

* `npm t`
* [Travis CI](https://travis-ci.org/erisu/cordova-cli/builds/583018998)

### Checklist

- [X] I've run the tests to see all new and existing tests pass
