### PR TITLE
chore: add codecov to display coverage in GH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,15 @@ node_js:
   - 10
   - 12
 
+install:
+  - npm install
+  - npm install -g codecov
+
 before_script:
   # Ensure that bin script actually runs on used Node.js version
   # to detect and avoid bugs such as apache/cordova-cli#339
   # (<https://github.com/apache/cordova-cli/issues/339>)
   - ./bin/cordova --version
+
+after_script:
+  - codecov


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Display coverage in GH


### Description
<!-- Describe your changes in detail -->
- Added install `codecov` step to `.travis.yml` and run `codecov` after script.


### Testing
<!-- Please describe in detail how you tested your changes. -->
CI
