### PR TITLE
fix: argument filtering in telemetry.track

### DIFF
--- a/spec/telemetry.spec.js
+++ b/spec/telemetry.spec.js
@@ -122,8 +122,7 @@ describe('telemetry', () => {
             expect(insight.track).toHaveBeenCalledWith(...args);
         });
 
-        // FIXME filtering is currently broken
-        xit('filters falsy and empty arguments [T010]', () => {
+        it('filters falsy and empty arguments [T010]', () => {
             const args = [null, [23], [], 42, ''];
             telemetry.track(...args);
             expect(insight.track).toHaveBeenCalledWith([23], 42);

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -50,15 +50,10 @@ function showPrompt () {
     });
 }
 
-function track () {
+function track (...args) {
     // Remove empty, null or undefined strings from arguments
-    for (var property in arguments) {
-        var val = arguments[property];
-        if (!val || val.length === 0) {
-            delete arguments.property;
-        }
-    }
-    insight.track.apply(insight, arguments);
+    const filteredArgs = args.filter(val => val && val.length !== 0);
+    insight.track(...filteredArgs);
 }
 
 function turnOn () {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`telemetry.track` is supposed to filter the arguments it receives and only pass truthy, non-empty arguments to `insight.track`. The purpose of this filtering is to ensure that the following call always produces nice results: https://github.com/apache/cordova-cli/blob/39141dd681b95e94ac9dea23a586f65589a2ba65/src/cli.js#L200
Without filtering and with `subcommand` unset, as would be the case when running e.g. `cordova help`, `help/undefined/successful` would be tracked. With filtering `help/successful` will be tracked.


This feature was broken (probably never worked as intended).

Fixing as discussed here: https://github.com/apache/cordova-cli/pull/471#pullrequestreview-302973791

### Testing
<!-- Please describe in detail how you tested your changes. -->
Automated tests pass


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change