### PR TITLE
Remove unsupported option --copy-from

### DIFF
--- a/doc/create.txt
+++ b/doc/create.txt
@@ -13,7 +13,6 @@ Create a Cordova project
 Options
 
     --template=<PATH|NPM PACKAGE|GIT URL> ... use a custom template located locally, in NPM, or GitHub.
-    --copy-from|src=<PATH> .................. deprecated, use --template instead.
     --link-to=<PATH> ........................ symlink to custom www assets without creating a copy.
     
 Example

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -118,7 +118,6 @@ cordova create path [id [name [config]]] [options]
 | Option | Description |
 |--------|-------------|
 | --template |  Use a custom template located locally, in NPM, or GitHub. |
-| --copy-from\|--src | _Deprecated_ <br/> Use --template instead. Specifies a directory from which to copy the current Cordova project. |
 |--link-to | Symlink to specified `www` directory without creating a copy. |
 
 ### Directory structure

--- a/src/cli.js
+++ b/src/cli.js
@@ -42,7 +42,6 @@ var knownOpts = {
     'noregistry': Boolean,
     'nohooks': Array,
     'shrinkwrap': Boolean,
-    'copy-from': String,
     'link-to': path,
     'searchpath': String,
     'variable': Array,
@@ -69,7 +68,6 @@ var shortHands = {
     'd': '--verbose',
     'v': '--version',
     'h': '--help',
-    'src': '--copy-from',
     't': '--template'
 };
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Apparently this once was an option for the create command. But there is no actual implementation for it, so using it would cause an error. Plus it's already deprecated.

Thus this could go in a patch release.