### PR TITLE
chore: drop node 6 and 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
     - $HOME/.npm
 
 node_js:
-  - 6
-  - 8
   - 10
   - 12
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ cache:
 
 environment:
   matrix:
-    - nodejs_version: 6
-    - nodejs_version: 8
     - nodejs_version: 10
     - nodejs_version: 12
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Cordova command line interface tool",
   "main": "cordova",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "bin": {
     "cordova": "./bin/cordova"


### PR DESCRIPTION
### Motivation and Context

Next major release, `cordova-cli@10.x` will no longer test or require code to be backwards compatible with node 6 and 8.

### Description

- Removes node 6 and 8 from testing and `package.json`.
- Updated minimum supported node version.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
