### PR TITLE
docs: undocument "platform save", again

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -202,7 +202,6 @@ cordova {platform | platforms} [
     add <platform-spec> [...] {--save | link=<path> } |
     {remove | rm}  platform [...] {--save}|
     {list | ls}  |
-    save |
     update ]
 ```
 


### PR DESCRIPTION
This removes an instance of `platform save` from the docs that had been missed in #476.