### PR TITLE
docs(config): undocument "autosave" setting

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -13,16 +13,14 @@ Options
 
 
 Syntax
-	cordova-cli config set <key> <value> ....... cordova config set autosave true
-	cordova-cli config get <key> ............... cordova config get autosave
-	cordova-cli config delete <key> ............ cordova config delete autosave
+	cordova-cli config set <key> <value> ....... cordova config set save-exact true
+	cordova-cli config get <key> ............... cordova config get save-exact
+	cordova-cli config delete <key> ............ cordova config delete save-exact
 	cordova-cli config edit .................... cordova config edit
 	cordova-cli config ls ...................... cordova config ls
 
 Options
-	autosave ...................... default setting = true
-	Allows the user to set save to true or false when adding platforms or plugins.
-	When false, platforms/plugins are not saved to `config.xml` and `package.json`.
+	save-exact ...................... default setting = false
 
 Examples
-	cordova config set autosave false
+	cordova config set save-exact true

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -626,7 +626,7 @@ cordova config delete <key>
 ### Examples
 
 ```
-cordova config set autosave false
+cordova config set save-exact true
 ```
 
 [Hooks guide]: http://cordova.apache.org/docs/en/latest/guide_appdev_hooks_index.md.html


### PR DESCRIPTION
Removes all documentation regarding the unsupported `autosave`
configuration setting.

Also see #483