### PR TITLE
refactor(create): depend directly on cordova-create

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "configstore": "^4.0.0",
     "cordova-common": "^3.1.0",
+    "cordova-create": "^2.0.0",
     "cordova-lib": "^9.0.0",
     "editor": "^1.0.0",
     "insight": "^0.10.1",

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -19,12 +19,13 @@ const path = require('path');
 const rewire = require('rewire');
 const { events, cordova } = require('cordova-lib');
 const telemetry = require('../src/telemetry');
-const cli = rewire('../src/cli');
 
 describe('cordova cli', () => {
-    let logger;
+    let cli, logger;
 
     beforeEach(() => {
+        cli = rewire('../src/cli');
+
         // Event registration is currently process-global. Since all jasmine
         // tests in a directory run in a single process (and in parallel),
         // logging events registered as a result of the "--verbose" flag in
@@ -116,12 +117,16 @@ describe('cordova cli', () => {
 
     describe('create', () => {
         beforeEach(() => {
-            spyOn(cordova, 'create').and.returnValue(Promise.resolve());
+            cli.__set__({
+                cordovaCreate: jasmine.createSpy('cordovaCreate').and.resolveTo()
+            });
         });
 
         it('Test#011 : calls cordova create', () => {
             return cli(['node', 'cordova', 'create', 'a', 'b', 'c', '--link-to', 'c:\\personalWWW']).then(() => {
-                expect(cordova.create).toHaveBeenCalledWith('a', 'b', 'c', jasmine.any(Object), jasmine.any(Object));
+                expect(cli.__get__('cordovaCreate')).toHaveBeenCalledWith(
+                    'a', 'b', 'c', jasmine.any(Object), jasmine.any(Object)
+                );
             });
         });
     });

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,6 +26,7 @@ var CordovaError = cordova_lib.CordovaError;
 var cordova = cordova_lib.cordova;
 var events = cordova_lib.events;
 var logger = require('cordova-common').CordovaLogger.get();
+var cordovaCreate = require('cordova-create');
 var Configstore = require('configstore');
 var conf = new Configstore(pkg.name + '-config');
 var editor = require('editor');
@@ -511,5 +512,5 @@ function create ([_, dir, id, name], args) {
         };
 
     }
-    return cordova.create(dir, id, name, cfg, events || undefined);
+    return cordovaCreate(dir, id, name, cfg, events || undefined);
 }


### PR DESCRIPTION
This will allow us to remove the `cordova.create` stub from
`cordova-lib`.

Moreover it flattens our dependency graph by one level:

### Old
![Dependency graph old](https://graphviz2.glitch.me/graphviz?graph=digraph+%22Cordova+Dependencies%22+%7B%0A%7B%22cordova-ios%22%2C+%22cordova-osx%22%7D+-%3E+%22xcode%22%3B%0A%22cordova-browser%22+-%3E+%22cordova-serve%22%3B%0A%22cordova%22+-%3E+%22cordova-common%22%3B%0A%22cordova%22+-%3E+%22cordova-lib%22%3B%0A%22plugman%22+-%3E+%22cordova-lib%22%3B%0A%22cordova-lib%22+-%3E+%22cordova-create%22%3B%0A%22cordova-lib%22+-%3E+%22cordova-common%22%3B%0A%22cordova-lib%22+-%3E+%22cordova-fetch%22%3B%0A%22cordova-lib%22+-%3E+%22cordova-serve%22%3B%0A%22cordova-create%22+-%3E+%22cordova-app-hello-world%22%3B%0A%22cordova-create%22+-%3E+%22cordova-common%22%3B%0A%22cordova-create%22+-%3E+%22cordova-fetch%22%3B%0A%22cordova-fetch%22+-%3E+%22cordova-common%22%3B%0A%22cordova-lib%22+-%3E+%7B%22cordova-ios%22%2C+%22cordova-osx%22%2C+%22cordova-browser%22%2C+%22other+platforms%22%7D%3B%0A%7B%22cordova-ios%22%2C+%22cordova-osx%22%2C+%22cordova-browser%22%2C+%22other+platforms%22%7D+-%3E+%7B%22cordova-common%22%2C+%22cordova-js%22%7D%3B%0A%7D%0A&layout=dot&format=svg&mode=download)

### New
![Dependency graph new](https://graphviz2.glitch.me/graphviz?graph=digraph+%22Cordova+Dependencies%22+%7B%0A%7B%22cordova-ios%22%2C+%22cordova-osx%22%7D+-%3E+xcode%3B%0A%22cordova-browser%22+-%3E+%22cordova-serve%22%3B%0Acordova+-%3E+%22cordova-common%22%3B%0Acordova+-%3E+%22cordova-lib%22%3B%0Acordova+-%3E+%22cordova-create%22%3B%0Aplugman+-%3E+%22cordova-lib%22%3B%0A%22cordova-lib%22+-%3E+%22cordova-common%22%3B%0A%22cordova-lib%22+-%3E+%22cordova-fetch%22%3B%0A%22cordova-lib%22+-%3E+%22cordova-serve%22%3B%0A%22cordova-create%22+-%3E+%22cordova-app-hello-world%22%3B%0A%22cordova-create%22+-%3E+%22cordova-common%22%3B%0A%22cordova-create%22+-%3E+%22cordova-fetch%22%3B%0A%22cordova-fetch%22+-%3E+%22cordova-common%22%3B%0A%22cordova-lib%22+-%3E+%7B%22cordova-ios%22%2C+%22cordova-osx%22%2C+%22cordova-browser%22%2C+%22other+platforms%22%7D%3B%0A%7B%22cordova-ios%22%2C+%22cordova-osx%22%2C+%22cordova-browser%22%2C+%22other+platforms%22%7D+-%3E+%7B%22cordova-common%22%2C+%22cordova-js%22%7D%3B%0A%7D%0A&layout=dot&format=svg&mode=download)
