### PR TITLE
refactor(create): do not expand ~ to $HOME anymore

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -498,10 +498,6 @@ function create ([_, dir, id, name], args) {
             );
         }
 
-        // Resolve tilda
-        // TODO: move to create and use sindresorhus/untildify
-        if (customWww.substr(0, 1) === '~') { customWww = path.join(process.env.HOME, customWww.substr(1)); }
-
         // Template config
         cfg.lib = {};
         cfg.lib.www = {


### PR DESCRIPTION
Expanding ~ is a shell feature and should not be done by us.