### PR TITLE
refactor(create): use cordova-create 3.0.0-nightly

### DIFF
--- a/doc/create.txt
+++ b/doc/create.txt
@@ -11,7 +11,6 @@ Create a Cordova project
 Options
 
     --template=<PATH|NPM PACKAGE|GIT URL> ... use a custom template located locally, in NPM, or GitHub.
-    --link-to=<PATH> ........................ symlink to custom www assets without creating a copy.
 
 Example
     cordova-cli create myapp com.mycompany.myteam.myapp MyApp

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -117,7 +117,6 @@ cordova create path [id [name]] [options]
 | Option | Description |
 |--------|-------------|
 | --template |  Use a custom template located locally, in NPM, or GitHub. |
-|--link-to | Symlink to specified `www` directory without creating a copy. |
 
 ### Directory structure
 
@@ -182,11 +181,6 @@ It is recommended not to check in `platforms/` and `plugins/` directories into v
 - Create a Cordova project in `myapp` directory using the specified ID and display name:
 
         cordova create myapp com.mycompany.myteam.myapp MyApp
-
-- Create a Cordova project with a symlink to an existing `www` directory. This can be useful if you have a custom build process or existing web assets that you want to use in your Cordova app:
-
-        cordova create myapp --link-to=../www
-
 
 ## cordova platform command
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "configstore": "^4.0.0",
     "cordova-common": "^3.1.0",
-    "cordova-create": "^2.0.0",
+    "cordova-create": "^3.0.0-nightly.2019.11.19.1d0d67e0",
     "cordova-lib": "^9.0.0",
     "editor": "^1.0.0",
     "insight": "^0.10.1",

--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -122,12 +122,14 @@ describe('cordova cli', () => {
             });
         });
 
-        it('Test#011 : calls cordova create', () => {
-            return cli(['node', 'cordova', 'create', 'a', 'b', 'c', '--link-to', 'c:\\personalWWW']).then(() => {
-                expect(cli.__get__('cordovaCreate')).toHaveBeenCalledWith(
-                    'a', 'b', 'c', jasmine.any(Object), jasmine.any(Object)
-                );
-            });
+        it('Test#011 : calls cordova create', async () => {
+            const dest = 'a';
+            const opts = { id: 'b', name: 'c', template: '../my-template' };
+            await cli(['node', 'cordova', 'create', dest, opts.id, opts.name, '--template', opts.template]);
+
+            expect(cli.__get__('cordovaCreate')).toHaveBeenCalledWith(
+                dest, jasmine.objectContaining(opts)
+            );
         });
     });
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,7 +15,6 @@
     under the License.
 */
 
-var path = require('path');
 var nopt = require('nopt');
 var updateNotifier = require('update-notifier');
 var pkg = require('../package.json');
@@ -48,7 +47,6 @@ var knownOpts = {
     noregistry: Boolean,
     nohooks: Array,
     shrinkwrap: Boolean,
-    'link-to': path,
     searchpath: String,
     variable: Array,
     link: Boolean,
@@ -412,7 +410,8 @@ function cli (inputArgs) {
         var port = undashed[1];
         return cordova.serve(port);
     } else if (cmd === 'create') {
-        return create(undashed, args);
+        const [, dest, id, name] = undashed;
+        return cordovaCreate(dest, { id, name, events, template: args.template });
     } else if (cmd === 'config') {
         // Don't need to do anything with cordova-lib since config was handled above
         return true;
@@ -460,29 +459,4 @@ function cli (inputArgs) {
         };
         return cordova[cmd](subcommand, targets, download_opts);
     }
-}
-
-function create ([_, dir, id, name], args) {
-    var cfg = {};
-
-    // Template path
-    var customWww = args['link-to'] || args.template;
-
-    if (customWww) {
-        // TODO Handle in create
-        if (!args.template && customWww.indexOf('http') === 0) {
-            throw new CordovaError(
-                'Only local paths for custom www assets are supported for linking' + customWww
-            );
-        }
-
-        // Template config
-        cfg.lib = {};
-        cfg.lib.www = {
-            url: customWww,
-            template: 'template' in args,
-            link: 'link-to' in args
-        };
-    }
-    return cordovaCreate(dir, id, name, cfg, events || undefined);
 }


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Have our CLI use the latest version of `cordova-create`.

Resolves apache/cordova-discuss#69

### Description
<!-- Describe your changes in detail -->
- remove support for --link-to option from code
- use --template option instead of --link-to in test
- remove --link-to option from docs
- update code & test to use new cordova-create interface



### Testing
<!-- Please describe in detail how you tested your changes. -->
- Updated the existing tests
- Manually tested `cordova create app`


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] I've updated the documentation if necessary
