### PR TITLE
feat: migrate "cordova info" lib logic to cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "loud-rejection": "^2.0.0",
     "nopt": "^4.0.1",
     "semver": "^6.2.0",
+    "systeminformation": "^4.26.9",
     "update-notifier": "^2.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "cordova-create": "^3.0.0-nightly.2019.11.19.1d0d67e0",
     "cordova-lib": "^9.0.0",
     "editor": "^1.0.0",
+    "execa": "^4.0.2",
+    "fs-extra": "^9.0.1",
     "insight": "^0.10.1",
     "loud-rejection": "^2.0.0",
     "nopt": "^4.0.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,6 +20,7 @@ var updateNotifier = require('update-notifier');
 var pkg = require('../package.json');
 var telemetry = require('./telemetry');
 var help = require('./help');
+const info = require('./info');
 var cordova_lib = require('cordova-lib');
 var CordovaError = cordova_lib.CordovaError;
 var cordova = cordova_lib.cordova;
@@ -339,6 +340,8 @@ function cli (inputArgs) {
         }
         return printHelp(remain);
     }
+
+    if (cmd === 'info') return info();
 
     // Don't need to do anything with cordova-lib since config was handled above
     if (cmd === 'config') return true;

--- a/src/info.js
+++ b/src/info.js
@@ -130,7 +130,10 @@ async function getProjectSettingsFiles (projectRoot) {
     // Create package.json snippet
     const pkgRaw = _fetchFileContents(path.join(projectRoot, 'package.json'));
     const pkgJson = JSON.parse(pkgRaw);
-    const pkgSnippet = `--- Start of Cordova JSON Snippet ---\n${JSON.stringify(pkgJson.cordova, null, 2)}\n--- End of Cordova JSON Snippet ---`;
+    const pkgSnippet = ['--- Start of Cordova JSON Snippet ---',
+        JSON.stringify(pkgJson.cordova, null, 2),
+        '--- End of Cordova JSON Snippet ---'
+    ].join('\n');
 
     return {
         header: 'Project Setting Files',

--- a/src/info.js
+++ b/src/info.js
@@ -69,33 +69,30 @@ async function getInstalledPlugins (projectRoot) {
 }
 
 async function getEnvironmentInfo () {
-    return Promise.all([
-        _getNpmVersion(),
-        osInfo()
-    ]).then(results => {
-        const { platform, distro, release, codename, kernel, arch, build } = results[1];
-        let formatRelease = release;
+    const [npmVersion, osInfoResult] = await Promise.all([_getNpmVersion(), osInfo()]);
+    const { platform, distro, release, codename, kernel, arch, build } = osInfoResult;
 
-        if (build) {
-            formatRelease = `${formatRelease} (${build})`;
-        }
+    let formatRelease = release;
 
-        const osFormat = [
-            platform === 'darwin' ? codename : distro,
-            formatRelease,
-            `(${platform} ${kernel})`,
-            `${arch}`
-        ];
+    if (build) {
+        formatRelease = `${formatRelease} (${build})`;
+    }
 
-        return {
-            header: 'Environment',
-            content: [
-                { key: 'OS', data: osFormat.join(' ') },
-                { key: 'Node', data: process.version },
-                { key: 'npm', data: results[0] }
-            ]
-        };
-    });
+    const osFormat = [
+        platform === 'darwin' ? codename : distro,
+        formatRelease,
+        `(${platform} ${kernel})`,
+        `${arch}`
+    ];
+
+    return {
+        header: 'Environment',
+        content: [
+            { key: 'OS', data: osFormat.join(' ') },
+            { key: 'Node', data: process.version },
+            { key: 'npm', data: npmVersion }
+        ]
+    };
 }
 
 async function getPlatformEnvironmentData (projectRoot) {

--- a/src/info.js
+++ b/src/info.js
@@ -109,9 +109,9 @@ async function getPlatformEnvironmentData (projectRoot) {
 
 async function getProjectSettingsFiles (projectRoot) {
     const cfgXml = _fetchFileContents(cdvLibUtil.projectConfig(projectRoot)).replace(/\n$/, '');
+
     // Create package.json snippet
-    const pkgRaw = _fetchFileContents(path.join(projectRoot, 'package.json'));
-    const pkgJson = JSON.parse(pkgRaw);
+    const pkgJson = require(path.join(projectRoot, 'package'));
     const pkgSnippet = ['--- Start of Cordova JSON Snippet ---',
         JSON.stringify(pkgJson.cordova, null, 2),
         '--- End of Cordova JSON Snippet ---'

--- a/src/info.js
+++ b/src/info.js
@@ -21,8 +21,8 @@ const execa = require('execa');
 const { osInfo } = require('systeminformation');
 const { cordova, cordova_platforms: { getPlatformApi } } = require('cordova-lib');
 
-const cdvLibUtil = require(require.resolve('cordova-lib/src/cordova/util'));
-const cdvPluginUtil = require(require.resolve('cordova-lib/src/cordova/plugin/util'));
+const cdvLibUtil = require('cordova-lib/src/cordova/util');
+const cdvPluginUtil = require('cordova-lib/src/cordova/plugin/util');
 
 // Cache
 let _installedPlatformsList = null;
@@ -33,9 +33,8 @@ let _installedPlatformsList = null;
 
 async function getCordovaDependenciesInfo () {
     // get self "Cordova CLI"
-    const cliPath = require.resolve('../package');
-    const cliPkg = require(cliPath);
-    const libPkg = require(require.resolve('cordova-lib/package'));
+    const cliPkg = require('../package');
+    const libPkg = require('cordova-lib/package');
     const cliDependencies = await _getLibDependenciesInfo(cliPkg.dependencies);
     const libDependencies = await _getLibDependenciesInfo(libPkg.dependencies);
 

--- a/src/info.js
+++ b/src/info.js
@@ -34,15 +34,11 @@ let _installedPlatformsList = null;
 async function getCordovaDependenciesInfo () {
     // get self "Cordova CLI"
     const cliPkg = require('../package');
-    const libPkg = require('cordova-lib/package');
     const cliDependencies = await _getLibDependenciesInfo(cliPkg.dependencies);
-    const libDependencies = await _getLibDependenciesInfo(libPkg.dependencies);
 
-    cliDependencies.forEach((i, x) => {
-        if (i.key === 'lib') {
-            cliDependencies[x].content = libDependencies;
-        }
-    });
+    const libPkg = require('cordova-lib/package');
+    const cliLibDep = cliDependencies.find(({ key }) => key === 'lib');
+    cliLibDep.content = await _getLibDependenciesInfo(libPkg.dependencies);
 
     return {
         header: 'Cordova Packages',

--- a/src/info.js
+++ b/src/info.js
@@ -156,11 +156,11 @@ function _fetchFileContents (filePath) {
     return fs.readFileSync(filePath, 'utf-8');
 }
 
-function _buildContentList (list, indentionBy = 1) {
+function _buildContentList (list, level = 1) {
     const content = [];
 
     for (const item of list) {
-        const padding = String.prototype.padStart((4 * indentionBy), ' ');
+        const padding = String.prototype.padStart((4 * level), ' ');
 
         if (item.fromFile) {
             item.data = `\n\n${item.data}\n`;
@@ -169,7 +169,7 @@ function _buildContentList (list, indentionBy = 1) {
         content.push(`${padding}${item.key} : ${item.data}`);
 
         if (item.content && Array.isArray(item.content)) {
-            return content.concat(_buildContentList(item.content, ++indentionBy));
+            return content.concat(_buildContentList(item.content, level + 1));
         }
     }
 

--- a/src/info.js
+++ b/src/info.js
@@ -53,8 +53,8 @@ async function getCordovaDependenciesInfo () {
 async function getInstalledPlatforms (projectRoot) {
     return _getInstalledPlatforms(projectRoot).then(platforms => {
         const header = 'Project Installed Platforms';
-        const content = Object.keys(platforms)
-            .map(key => ({ key, data: platforms[key] }));
+        const content = Object.entries(platforms)
+            .map(([key, data]) => ({ key, data }));
 
         return { header, content };
     });

--- a/src/info.js
+++ b/src/info.js
@@ -194,14 +194,11 @@ const _failSafeSpawn = (command, args) => execa(command, args).then(
 );
 
 const _createSection = section => {
-    let content = [];
-
-    content.push(''); // Start of new section
-    content.push(`${section.header}:`);
-    content.push('');
+    // Start of new section
+    const content = ['', `${section.header}:`, ''];
 
     if (Array.isArray(section.content)) {
-        content = content.concat(_buildContentList(section.content));
+        content.push(..._buildContentList(section.content));
     } else {
         content.push(section.content);
     }

--- a/src/info.js
+++ b/src/info.js
@@ -218,16 +218,16 @@ module.exports = async function () {
         getProjectSettingsFiles(projectRoot)
     ]);
 
-    let content = [];
+    const content = [];
     results.forEach(section => {
         if (Array.isArray(section)) {
             // Handle a Group of Sections
             section.forEach(subSection => {
-                content = content.concat(_createSection(subSection));
+                content.push(..._createSection(subSection));
             });
         } else {
             // Handle a Single Section
-            content = content.concat(_createSection(section));
+            content.push(..._createSection(section));
         }
     });
 

--- a/src/info.js
+++ b/src/info.js
@@ -209,28 +209,27 @@ const _createSection = section => {
 module.exports = async function () {
     const projectRoot = cdvLibUtil.cdProjectRoot();
 
-    Promise.all([
+    const results = await Promise.all([
         getCordovaDependenciesInfo(),
         getInstalledPlatforms(projectRoot),
         getInstalledPlugins(projectRoot),
         getEnvironmentInfo(),
         getPlatformEnvironmentData(projectRoot),
         getProjectSettingsFiles(projectRoot)
-    ]).then(results => {
-        let content = [];
+    ]);
 
-        results.forEach(section => {
-            if (Array.isArray(section)) {
-                // Handle a Group of Sections
-                section.forEach(grouppedSection => {
-                    content = content.concat(_createSection(grouppedSection));
-                });
-            } else {
-                // Handle a Single Section
-                content = content.concat(_createSection(section));
-            }
-        });
-
-        cordova.emit('results', content.join('\n'));
+    let content = [];
+    results.forEach(section => {
+        if (Array.isArray(section)) {
+            // Handle a Group of Sections
+            section.forEach(grouppedSection => {
+                content = content.concat(_createSection(grouppedSection));
+            });
+        } else {
+            // Handle a Single Section
+            content = content.concat(_createSection(section));
+        }
     });
+
+    cordova.emit('results', content.join('\n'));
 };

--- a/src/info.js
+++ b/src/info.js
@@ -77,7 +77,6 @@ async function getEnvironmentInfo () {
     const osFormat = [
         platform === 'darwin' ? codename : distro,
         release + optionalBuildSuffix,
-        build ? `(${build})` : '',
         `(${platform} ${kernel})`,
         `${arch}`
     ];
@@ -128,10 +127,7 @@ async function getProjectSettingsFiles (projectRoot) {
         children: [
             { key: 'config.xml', value: `${cfgXml}` },
             { key: 'package.json', value: pkgSnippet }
-        ],
-        options: {
-            addNewLineSep: true
-        }
+        ]
     };
 }
 
@@ -192,7 +188,7 @@ function _formatNodeList (list, level = 0) {
         let itemString = `${indent}${item.key}:`;
 
         if ('value' in item) {
-            // Start Multiline items on a new line
+            // Pad multi-line values with a new line on either end
             itemString += (/[\r\n]/.test(item.value))
                 ? `\n${item.value.trim()}\n`
                 : ` ${item.value}`;

--- a/src/info.js
+++ b/src/info.js
@@ -223,7 +223,7 @@ function _buildContentList (list, indentionBy = 1) {
 /*
  * @deprecated will be removed when platforms implement the calls.
  */
-function _getPlatformInfo (platform) {
+async function _getPlatformInfo (platform) {
     switch (platform) {
     case 'ios':
         return _failSafeSpawn('xcodebuild', ['-version']);

--- a/src/info.js
+++ b/src/info.js
@@ -140,14 +140,10 @@ async function _getLibDependenciesInfo (dependencies) {
 }
 
 async function _getInstalledPlatforms (projectRoot) {
-    if (_installedPlatformsList) {
-        return _installedPlatformsList;
-    } else {
-        return cdvLibUtil.getInstalledPlatformsWithVersions(projectRoot).then(platforms => {
-            _installedPlatformsList = platforms;
-            return _installedPlatformsList;
-        });
+    if (!_installedPlatformsList) {
+        _installedPlatformsList = await cdvLibUtil.getInstalledPlatformsWithVersions(projectRoot);
     }
+    return _installedPlatformsList;
 }
 
 async function _getNpmVersion () {

--- a/src/info.js
+++ b/src/info.js
@@ -1,0 +1,283 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs-extra');
+const execa = require('execa');
+const { osInfo } = require('systeminformation');
+const { cordova, cordova_platforms: { getPlatformApi } } = require('cordova-lib');
+
+const cdvLibUtil = require(require.resolve('cordova-lib/src/cordova/util'));
+const cdvPluginUtil = require(require.resolve('cordova-lib/src/cordova/plugin/util'));
+
+// Cache
+let _installedPlatformsList = null;
+
+/*
+ * Sections
+ */
+
+async function getCordovaDependenciesInfo () {
+    // get self "Cordova CLI"
+    const cliPath = require.resolve('../package');
+    const cliPkg = require(cliPath);
+    const libPkg = require(require.resolve('cordova-lib/package'));
+    const cliDependencies = await _getLibDependenciesInfo(cliPkg.dependencies);
+    const libDependencies = await _getLibDependenciesInfo(libPkg.dependencies);
+
+    cliDependencies.forEach((i, x) => {
+        if (i.key === 'lib') {
+            cliDependencies[x].content = libDependencies;
+        }
+    });
+
+    return {
+        header: 'Cordova Packages',
+        content: [{ key: 'cli', data: cliPkg.version, content: cliDependencies }]
+    };
+}
+
+async function getInstalledPlatforms (projectRoot) {
+    return _getInstalledPlatforms(projectRoot).then(platforms => {
+        const header = 'Project Installed Platforms';
+        const content = Object.keys(platforms)
+            .map(key => ({ key, data: platforms[key] }));
+
+        return { header, content };
+    });
+}
+
+async function getInstalledPlugins (projectRoot) {
+    const header = 'Project Installed Plugins';
+    const content = cdvPluginUtil.getInstalledPlugins(projectRoot)
+        .map(plugin => ({ key: plugin.id, data: plugin.version }));
+
+    return { header, content };
+}
+
+async function getEnvironmentInfo () {
+    let formatOsInfo;
+    if (process.platform === 'darwin') {
+        const { stdout: osInfo } = await execa('sw_vers');
+
+        formatOsInfo = osInfo
+            .replace(/\t/g, '')
+            .replace(/\n/g, ':')
+            .split(':')
+            .filter((i, x) => x % 2 ? i : false)
+            .join(' ') + ')';
+
+        formatOsInfo.splice = function (start, delCount, newSubStr) {
+
+        };
+
+        const buildVersionStart = formatOsInfo.lastIndexOf(' ') + 1;
+        formatOsInfo = `${formatOsInfo.slice(0, buildVersionStart)}(${formatOsInfo.slice(buildVersionStart + Math.abs(0))}`;
+        formatOsInfo = `${formatOsInfo} (${process.arch})`;
+    } else {
+        formatOsInfo = `${os.type} ${os.release} (${process.arch})`;
+    }
+
+    return Promise.all([
+        _getNpmVersion(),
+        osInfo()
+    ]).then(results => {
+        const { platform, distro, release, codename, kernel, arch, build } = results[1];
+        let formatRelease = release;
+
+        if (build) {
+            formatRelease = `${formatRelease} (${build})`;
+        }
+
+        const osFormat = [
+            platform === 'darwin' ? codename : distro,
+            formatRelease,
+            `(${platform} ${kernel})`,
+            `${arch}`
+        ];
+
+        return {
+            header: 'Environment',
+            content: [
+                { key: 'OS', data: osFormat.join(' ') },
+                { key: 'Node', data: process.version },
+                { key: 'npm', data: results[0] }
+            ]
+        };
+    });
+}
+
+async function getPlatformEnvironmentData (projectRoot) {
+    return _getInstalledPlatforms(projectRoot).then(installedPlatforms => {
+        const sections = [];
+
+        Object.keys(installedPlatforms).forEach(platform => {
+            const platformApi = getPlatformApi(platform);
+            if (platformApi && platformApi.getEnvironmentInfo) {
+                platformApi.getEnvironmentInfo().then(content => {
+                    sections.push({
+                        header: `${platform} Environment`,
+                        content
+                    });
+                });
+            } else {
+                _getPlatformInfo(platform).then(content => {
+                    sections.push({
+                        header: `${platform} Environment`,
+                        content: content
+                    });
+                });
+            }
+        });
+
+        return sections;
+    });
+}
+
+async function getProjectSettingsFiles (projectRoot) {
+    const cfgXml = _fetchFileContents(cdvLibUtil.projectConfig(projectRoot)).replace(/\n$/, '');
+    // Create package.json snippet
+    const pkgRaw = _fetchFileContents(path.join(projectRoot, 'package.json'));
+    const pkgJson = JSON.parse(pkgRaw);
+    const pkgSnippet = `--- Start of Cordova JSON Snippet ---\n${JSON.stringify(pkgJson.cordova, null, 2)}\n--- End of Cordova JSON Snippet ---`;
+
+    return {
+        header: 'Project Setting Files',
+        content: [
+            { key: 'config.xml', data: cfgXml, fromFile: true },
+            { key: 'package.json', data: pkgSnippet, fromFile: true }
+        ]
+    };
+}
+
+/*
+ * Section Data Helpers
+ */
+
+async function _getLibDependenciesInfo (dependencies) {
+    const cordovaPrefix = 'cordova-';
+    const versionFor = name => require(`${name}/package`).version;
+
+    return Object.keys(dependencies)
+        .filter(name => name.startsWith(cordovaPrefix))
+        .map(name => ({ key: name.slice(cordovaPrefix.length), data: versionFor(name) }));
+}
+
+async function _getInstalledPlatforms (projectRoot) {
+    if (_installedPlatformsList) {
+        return _installedPlatformsList;
+    } else {
+        return cdvLibUtil.getInstalledPlatformsWithVersions(projectRoot).then(platforms => {
+            _installedPlatformsList = platforms;
+            return _installedPlatformsList;
+        });
+    }
+}
+
+async function _getNpmVersion () {
+    const { stdout: npmVersion } = await execa('npm', ['-v']);
+    return npmVersion;
+}
+
+function _fetchFileContents (filePath) {
+    if (!fs.existsSync(filePath)) return 'File Not Found';
+
+    return fs.readFileSync(filePath, 'utf-8');
+}
+
+function _buildContentList (list, indentionBy = 1) {
+    const content = [];
+
+    for (const item of list) {
+        const padding = String.prototype.padStart((4 * indentionBy), ' ');
+
+        if (item.fromFile) {
+            item.data = `\n\n${item.data}\n`;
+        }
+
+        content.push(`${padding}${item.key} : ${item.data}`);
+
+        if (item.content && Array.isArray(item.content)) {
+            return content.concat(_buildContentList(item.content, ++indentionBy));
+        }
+    }
+
+    return content;
+}
+
+/*
+ * @deprecated will be removed when platforms implement the calls.
+ */
+function _getPlatformInfo (platform) {
+    switch (platform) {
+    case 'ios':
+        return _failSafeSpawn('xcodebuild', ['-version']);
+    case 'android':
+        return _failSafeSpawn('android', ['list', 'target']);
+    }
+}
+
+const _failSafeSpawn = (command, args) => execa(command, args).then(
+    ({ stdout }) => stdout,
+    err => `ERROR: ${err.message}`
+);
+
+const _createSection = section => {
+    let content = [];
+
+    content.push(''); // Start of new section
+    content.push(`${section.header}:`);
+    content.push('');
+
+    if (Array.isArray(section.content)) {
+        content = content.concat(_buildContentList(section.content));
+    } else {
+        content.push(section.content);
+    }
+
+    return content;
+};
+
+module.exports = async function () {
+    const projectRoot = cdvLibUtil.cdProjectRoot();
+
+    Promise.all([
+        getCordovaDependenciesInfo(),
+        getInstalledPlatforms(projectRoot),
+        getInstalledPlugins(projectRoot),
+        getEnvironmentInfo(),
+        getPlatformEnvironmentData(projectRoot),
+        getProjectSettingsFiles(projectRoot)
+    ]).then(results => {
+        let content = [];
+
+        results.forEach(section => {
+            if (Array.isArray(section)) {
+                // Handle a Group of Sections
+                section.forEach(grouppedSection => {
+                    content = content.concat(_createSection(grouppedSection));
+                });
+            } else {
+                // Handle a Single Section
+                content = content.concat(_createSection(section));
+            }
+        });
+
+        cordova.emit('results', content.join('\n'));
+    });
+};

--- a/src/info.js
+++ b/src/info.js
@@ -147,8 +147,7 @@ async function _getInstalledPlatforms (projectRoot) {
 }
 
 async function _getNpmVersion () {
-    const { stdout: npmVersion } = await execa('npm', ['-v']);
-    return npmVersion;
+    return (await execa('npm', ['-v'])).stdout;
 }
 
 function _fetchFileContents (filePath) {

--- a/src/info.js
+++ b/src/info.js
@@ -16,7 +16,6 @@
 */
 
 const path = require('path');
-const os = require('os');
 const fs = require('fs-extra');
 const execa = require('execa');
 const { osInfo } = require('systeminformation');
@@ -71,28 +70,6 @@ async function getInstalledPlugins (projectRoot) {
 }
 
 async function getEnvironmentInfo () {
-    let formatOsInfo;
-    if (process.platform === 'darwin') {
-        const { stdout: osInfo } = await execa('sw_vers');
-
-        formatOsInfo = osInfo
-            .replace(/\t/g, '')
-            .replace(/\n/g, ':')
-            .split(':')
-            .filter((i, x) => x % 2 ? i : false)
-            .join(' ') + ')';
-
-        formatOsInfo.splice = function (start, delCount, newSubStr) {
-
-        };
-
-        const buildVersionStart = formatOsInfo.lastIndexOf(' ') + 1;
-        formatOsInfo = `${formatOsInfo.slice(0, buildVersionStart)}(${formatOsInfo.slice(buildVersionStart + Math.abs(0))}`;
-        formatOsInfo = `${formatOsInfo} (${process.arch})`;
-    } else {
-        formatOsInfo = `${os.type} ${os.release} (${process.arch})`;
-    }
-
     return Promise.all([
         _getNpmVersion(),
         osInfo()

--- a/src/info.js
+++ b/src/info.js
@@ -72,15 +72,12 @@ async function getEnvironmentInfo () {
     const [npmVersion, osInfoResult] = await Promise.all([_getNpmVersion(), osInfo()]);
     const { platform, distro, release, codename, kernel, arch, build } = osInfoResult;
 
-    let formatRelease = release;
-
-    if (build) {
-        formatRelease = `${formatRelease} (${build})`;
-    }
+    const optionalBuildSuffix = build ? ` (${build})` : '';
 
     const osFormat = [
         platform === 'darwin' ? codename : distro,
-        formatRelease,
+        release + optionalBuildSuffix,
+        build ? `(${build})` : '',
         `(${platform} ${kernel})`,
         `${arch}`
     ];

--- a/src/info.js
+++ b/src/info.js
@@ -176,7 +176,7 @@ function _buildContentList (list, level = 1) {
     return content;
 }
 
-/*
+/**
  * @deprecated will be removed when platforms implement the calls.
  */
 async function _getPlatformInfo (platform) {

--- a/src/info.js
+++ b/src/info.js
@@ -222,8 +222,8 @@ module.exports = async function () {
     results.forEach(section => {
         if (Array.isArray(section)) {
             // Handle a Group of Sections
-            section.forEach(grouppedSection => {
-                content = content.concat(_createSection(grouppedSection));
+            section.forEach(subSection => {
+                content = content.concat(_createSection(subSection));
             });
         } else {
             // Handle a Single Section


### PR DESCRIPTION
### Motivation, Context & Description

- Migrate `cordova info` lib logic to CLI.
- This PR:
  - closes https://github.com/apache/cordova-lib/issues/659
  - closes https://github.com/apache/cordova-lib/issues/660
  - closes https://github.com/apache/cordova-lib/issues/661
  - closes https://github.com/apache/cordova-cli/issues/301

Migrating the `cordova info` logic to cli makes it easier to grab the CLI version. Even though we document to install cordova globally and that we can use a spawn to grab the version, this allows us to properly display the information level of the CLI and its dependencies if the CLI was installed locally to the project.

- Add `systeminformation` dependency to easily grab more detailed OS information
- Expanded on the printout for plugins
- Shorten the `package.json` output to snippet only the cordova data which is the only important data needed for debugging

#### Example Printout

```
$ npx cordova info
Warning: using prerelease version 10.0.0-dev (cordova-lib@9.0.1)

Cordova Packages:

    cli : 10.0.0-dev
        common : 3.2.1
        create : 3.0.0
        lib : 9.0.1
            common : 3.2.1
            create : 3.0.0
            fetch : 3.0.0
            serve : 3.0.0

Project Installed Platforms:

    android : 9.1.0-nightly.2020.7.1.cccf8124

Project Installed Plugins:

    cordova-plugin-whitelist : 1.3.4

Environment:

    OS : macOS Catalina 10.15.5 (19F101) (19F101) (darwin 19.5.0) x64
    Node : v14.4.0
    npm : 6.14.5

android Environment:

    android : ERROR: Command failed with ENOENT: android list target
spawn android ENOENT

Project Setting Files:

    config.xml :
<?xml version='1.0' encoding='utf-8'?>
<widget id="io.cordova.hellocordova" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
    <name>HelloCordova</name>
    <description>
        A sample Apache Cordova application that responds to the deviceready event.
    </description>
    <author email="dev@cordova.apache.org" href="http://cordova.io">
        Apache Cordova Team
    </author>
    <content src="index.html" />
    <access origin="*" />
    <allow-intent href="http://*/*" />
    <allow-intent href="https://*/*" />
    <allow-intent href="tel:*" />
    <allow-intent href="sms:*" />
    <allow-intent href="mailto:*" />
    <allow-intent href="geo:*" />
    <platform name="android">
        <allow-intent href="market:*" />
    </platform>
    <platform name="ios">
        <allow-intent href="itms:*" />
        <allow-intent href="itms-apps:*" />
    </platform>
</widget>

    package.json :
--- Start of Cordova JSON Snippet ---
{
  "plugins": {
    "cordova-plugin-whitelist": {}
  },
  "platforms": [
    "android"
  ]
}
--- End of Cordova JSON Snippet ---
```

The above example is an Android project. 

The above example's `android Environment:` printout is the original printout logic that is used for Android. iOS also has original logic.

Ignore that the printout displays an error as my environment is not configured with that binary. That printout is the original printout.

The platform environment data should be fetched from the platform directly. This PR has also introduced the call to the platform API to fetch this data but no platform today supports this API. This is a future task that is to be done in a separate PR in their own repos. Requests or feedback on what should be displayed in this section is out of this PR's scope.

Any improvement requests in regards to platform's environment printout is out of this PR scope and is not to be commented in this PR.

### Testing

- `npm t`

*Note: CLI does not need a special lib version for this test as it will not call lib in this case.*

### Checklist

- [x] I've run the tests to see all new and existing tests pass
