### PR TITLE
breaking: bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,19 +29,19 @@
     "cli"
   ],
   "dependencies": {
-    "configstore": "^4.0.0",
-    "cordova-common": "^3.1.0",
-    "cordova-create": "^3.0.0-nightly.2019.11.19.1d0d67e0",
-    "cordova-lib": "^9.0.0",
+    "configstore": "^5.0.1",
+    "cordova-common": "^4.0.2",
+    "cordova-create": "^3.0.0",
+    "cordova-lib": "^9.0.1",
     "editor": "^1.0.0",
-    "execa": "^4.0.2",
+    "execa": "^4.0.3",
     "fs-extra": "^9.0.1",
-    "insight": "^0.10.1",
-    "loud-rejection": "^2.0.0",
-    "nopt": "^4.0.1",
-    "semver": "^6.2.0",
-    "systeminformation": "^4.26.9",
-    "update-notifier": "^2.5.0"
+    "insight": "^0.10.3",
+    "loud-rejection": "^2.2.0",
+    "nopt": "^4.0.3",
+    "semver": "^7.3.2",
+    "systeminformation": "^4.26.10",
+    "update-notifier": "^4.1.0"
   },
   "devDependencies": {
     "@cordova/eslint-config": "^2.0.0",


### PR DESCRIPTION
### Motivation, Context & Description

Use Latest Dependencies

- configstored@^5.0.1
- cordova-commond@^4.0.2
- cordova-created@^3.0.0
- cordova-libd@^9.0.1
- execad@^4.0.3
- insightd@^0.10.3
- loud-rejectiond@^2.2.0
- noptd@^4.0.3
- semverd@^7.3.2
- systeminformationd@^4.26.10
- update-notifierd@^4.1.0

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
