### PR TITLE
test: fix node.js version check

### DIFF
--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -493,8 +493,8 @@ describe('cordova cli', () => {
             cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
 
             return cli(['node', 'cordova']).then(() => {
-                const errorMsg = logger.warn.calls.argsFor(1).toString();
-                expect(errorMsg).toMatch(/v6.1.0 is no longer supported./);
+                const errorMsg = logger.warn.calls.allArgs().toString();
+                expect(errorMsg).toMatch(/Node.js v6.1.0 is no longer supported./);
             });
         });
 
@@ -504,8 +504,8 @@ describe('cordova cli', () => {
             cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
 
             return cli(['node', 'cordova']).then(() => {
-                const errorMsg = logger.warn.calls.argsFor(1).toString();
-                expect(errorMsg).toBeFalsy();
+                const errorMsg = logger.warn.calls.allArgs().toString();
+                expect(errorMsg).not.toMatch(/Node.js v6.1.0 is no longer supported./);
             });
         });
 
@@ -515,8 +515,8 @@ describe('cordova cli', () => {
             cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
 
             return cli(['node', 'cordova']).then(() => {
-                const errorMsg = logger.warn.calls.argsFor(1).toString();
-                expect(errorMsg).toMatch(/v8.0.0 has been deprecated./);
+                const errorMsg = logger.warn.calls.allArgs().toString();
+                expect(errorMsg).toMatch(/Node.js v8.0.0 has been deprecated./);
             });
         });
 
@@ -526,8 +526,8 @@ describe('cordova cli', () => {
             cli.__set__('NODE_VERSION_REQUIREMENT', '>=8');
 
             return cli(['node', 'cordova']).then(() => {
-                const errorMsg = logger.warn.calls.argsFor(1).toString();
-                expect(errorMsg).toBeFalsy();
+                const errorMsg = logger.warn.calls.allArgs().toString();
+                expect(errorMsg).not.toMatch(/Node.js v8.0.0 has been deprecated./);
             });
         });
     });


### PR DESCRIPTION
### Motivation, Context & Description

Two of the test fails when removing the `-dev` suffix.

After investigating, the `-dev` suffix will printout the `prerelease` warning but when the suffix is removed the warning is not printed. This shifts the indices on which the Node.js version validation message is displayed on.

This PR will take all the messages that are passed in the logger and concat them. It will check across all message for the unique snippet for the node validation message.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
