### PR TITLE
(android) Replace deprecated `android` command with `avdmanager`

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -171,7 +171,7 @@ const _legacyPlatformInfo = {
     }],
     android: async () => [{
         key: 'android',
-        value: await _failSafeSpawn('android', ['list', 'target'])
+        value: await _failSafeSpawn('avdmanager', ['list', 'target'])
     }]
 };
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The `android` command is deprecated. When you run the command, it displays the following:

```
*************************************************************************
The "android" command is deprecated.
For manual SDK, AVD, and project management, please use Android Studio.
For command-line tools, use tools/bin/sdkmanager and tools/bin/avdmanager
*************************************************************************
Running /path/to/android-sdk/tools/bin/avdmanager list target
```

On many systems the `android` command isn't even in the PATH and so attempting to run the original command fails.


### Description
<!-- Describe your changes in detail -->

Replaced the `android` command with `avdmanager` as suggested by the displayed warning.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I made the change locally and tested by running `cordova info`.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary

(this issue was found by the team working on https://volt.build/)