### PR TITLE
chore(pkg): remove deprecated no-op field "preferGlobal"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "cordova",
   "version": "10.0.1-dev",
-  "preferGlobal": true,
   "description": "Cordova command line interface tool",
   "main": "cordova",
   "engines": {


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#preferglobal

Related to https://github.com/apache/cordova/issues/55
