### PR TITLE
chore(dep): systeminformation@4.26.10 -> 4.34.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5641,9 +5641,9 @@
       }
     },
     "systeminformation": {
-      "version": "4.27.3",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.27.3.tgz",
-      "integrity": "sha512-0Nc8AYEK818h7FI+bbe/kj7xXsMD5zOHvO9alUqQH/G4MHXu5tHQfWqC/bzWOk4JtoQPhnyLgxMYncDA2eeSBw=="
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.34.6.tgz",
+      "integrity": "sha512-JWcrnfBqkws9R12jTYF7+zl59bdhL/+sw6efHZllIdtztrRfyykL4Bbr0aTRHQqDP0tjFhZOlRHifPSSmdqmFg=="
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "loud-rejection": "^2.2.0",
     "nopt": "^4.0.3",
     "semver": "^7.3.2",
-    "systeminformation": "^4.26.10",
+    "systeminformation": "^4.34.6",
     "update-notifier": "^4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

systeminformation has a [documented](https://www.npmjs.com/advisories/1590) vulnerability for command injection involving the method `inetLatency()`.

I don't know if this method is used at all in any of our code paths, but better safe than sorry.

### Description
<!-- Describe your changes in detail -->

Updated `systeminformation` from version 4.26.10 to 4.34.6

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test`.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
