### PR TITLE
Update `create` doc with proper default values

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -110,7 +110,7 @@ cordova create path [id [name]] [options]
 | Value | Description   |
 |-------|---------------|
 | path  |  Directory which should not already exist. Cordova will create this directory. For more details on the directory structure, see below. |
-| id    | _Default_: `io.cordova.hellocordova` <br/>  Reverse domain-style identifier that maps to `id` attribute of `widget` element in `config.xml`. This can be changed but there may be code generated using this value, such as Java package names. It is recommended that you select an appropriate value.  |
+| id    | _Default_: `io.cordova.helloCordova` <br/>  Reverse domain-style identifier that maps to `id` attribute of `widget` element in `config.xml`. This can be changed but there may be code generated using this value, such as Java package names. It is recommended that you select an appropriate value.  |
 | name  | _Default_: `Hello Cordova` <br/> Application's display title that maps `name` element in `config.xml` file. This can be changed but there may be code generated using this value, such as Java class names. The default value is `Hello Cordova`, but it is recommended that you select an appropriate value. |
 
 ### Options

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -111,7 +111,7 @@ cordova create path [id [name]] [options]
 |-------|---------------|
 | path  |  Directory which should not already exist. Cordova will create this directory. For more details on the directory structure, see below. |
 | id    | _Default_: `io.cordova.hellocordova` <br/>  Reverse domain-style identifier that maps to `id` attribute of `widget` element in `config.xml`. This can be changed but there may be code generated using this value, such as Java package names. It is recommended that you select an appropriate value.  |
-| name  | _Default_: `HelloCordova` <br/> Application's display title that maps `name` element in `config.xml` file. This can be changed but there may be code generated using this value, such as Java class names. The default value is `HelloCordova`, but it is recommended that you select an appropriate value. |
+| name  | _Default_: `Hello Cordova` <br/> Application's display title that maps `name` element in `config.xml` file. This can be changed but there may be code generated using this value, such as Java class names. The default value is `Hello Cordova`, but it is recommended that you select an appropriate value. |
 
 ### Options
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Docs


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Mixed default values for `create` between cli doc, cordova-android and cordova-ios.


### Description
<!-- Describe your changes in detail -->
After reviewing the various values used in cordova-android and cordova-ios for `create` here are my suggested proper defaults:
- **id** / package name: `io.cordova.helloCordova`
- **name** / project name: `Hello Cordova`

These are the most common values already used but not always ; see linked PRs to fix this situation.


### Testing
<!-- Please describe in detail how you tested your changes. -->
in cordova-android and cordova-ios respectively 


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
