### PR TITLE
Remove plugin save command from CLI help docs 

### DIFF
--- a/doc/plugin.txt
+++ b/doc/plugin.txt
@@ -31,7 +31,6 @@ Manage project plugins
 
 
     list .............................. List currently installed plugins
-    save .............................. Saves the information for all currently added plugins to config.xml
 
 Syntax
     <plugin-spec> : <pluginID>[@<version>]|<directory>|<url>[#<commit-ish>][:subdir]


### PR DESCRIPTION
### Motivation and Context

Closes #558 


### Description

Removes the `cordova plugin save` command from the help docs as the command has already been removed.

