### PR TITLE
chore: bump version to 11.0.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova",
-  "version": "10.0.1-dev",
+  "version": "11.0.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova",
-  "version": "10.0.1-dev",
+  "version": "11.0.0-dev",
   "description": "Cordova command line interface tool",
   "main": "cordova",
   "engines": {


### PR DESCRIPTION
### Motivation and Context

Prepare for Cordova CLI 11 Release

### Description

Bump CLI version for next major release 11.0.0-dev.

### Testing

- GH Actions

### Checklist

- [x] I've run the tests to see all new and existing tests pass
