### PR TITLE
feat!: update node support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cordova command line interface tool",
   "main": "cordova",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "bin": {
     "cordova": "./bin/cordova"


### PR DESCRIPTION
### Motivation and Context

Prepare for Cordova CLI 11 Release

### Description

* Drop node 10.0.0
* Bump node engine requirement to `>= 12.0.0`
* Update GitHub Actions CI testing to cover:
  * 12.x
  * 14.x
  * 16.x

### Testing

- GH Actions

### Checklist

- [x] I've run the tests to see all new and existing tests pass
