### PR TITLE
remove potential error when setting exit code

### DIFF
--- a/bin/cordova
+++ b/bin/cordova
@@ -29,7 +29,11 @@ cli(process.argv).catch(err => {
         const errorOutput = typeof err === 'string' ? err : util.inspect(err);
         throw new CordovaError('Promise rejected with non-error: ' + errorOutput);
     }
-    process.exitCode = err.code || 1;
+    if (typeof err.code !== "number") {
+        process.exitCode = 1;
+    } else {
+        process.exitCode = err.code;
+    }
 
     // We cannot emit an error event here, as that would cause another error
     console.error(err.message);

--- a/bin/cordova
+++ b/bin/cordova
@@ -29,7 +29,7 @@ cli(process.argv).catch(err => {
         const errorOutput = typeof err === 'string' ? err : util.inspect(err);
         throw new CordovaError('Promise rejected with non-error: ' + errorOutput);
     }
-    if (typeof err.code !== "number") {
+    if (typeof err.code !== 'number') {
         process.exitCode = 1;
     } else {
         process.exitCode = err.code;


### PR DESCRIPTION
this PR implements a more reliable way of setting the CLI's exit code in error cases.

Previously, I encountered this error when running the cli:
```console
$ cordova build
TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received type string ('ERR_UNHANDLED_ERROR')
    at process.set [as exitCode] (node:internal/bootstrap/node:123:9)
    at /opt/nodejs/lib/node_modules/cordova/bin/cordova:33:22
```

With this version, I get to see the root problem:
```console
$ cordova build
Unhandled error. ('Parsing /home/me/hello/config.xml failed')
```

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
