### PR TITLE
fix: ensure CLI exits with non-zero code on errors

### DIFF
--- a/bin/cordova
+++ b/bin/cordova
@@ -37,4 +37,5 @@ cli(process.argv).catch(err => {
     // We cannot emit an error event here, as that would cause another error
     console.error(err.message);
     events.emit('verbose', err.stack);
+    process.exit(process.exitCode);
 });

--- a/bin/cordova
+++ b/bin/cordova
@@ -37,5 +37,4 @@ cli(process.argv).catch(err => {
     // We cannot emit an error event here, as that would cause another error
     console.error(err.message);
     events.emit('verbose', err.stack);
-    process.exit(process.exitCode);
 });

--- a/src/cli.js
+++ b/src/cli.js
@@ -140,6 +140,7 @@ module.exports = function (inputArgs) {
 function printHelp (command) {
     const result = help([command]);
     cordova.emit('results', result);
+    return result;
 }
 
 function cli (inputArgs) {
@@ -150,6 +151,15 @@ function cli (inputArgs) {
             logger.error(err.message);
         } else {
             logger.error(err);
+        }
+        process.exit(1);
+    });
+
+    process.on('unhandledRejection', function (reason) {
+        const msg = reason instanceof Error ? reason.message : String(reason);
+        logger.error(msg);
+        if (reason instanceof Error) {
+            events.emit('verbose', reason.stack);
         }
         process.exit(1);
     });


### PR DESCRIPTION
## Summary

Fixes the CLI silently exiting with code 0 when errors occur as unhandled rejections.

**Changes:**

- **`src/cli.js`**: Add `unhandledRejection` handler so rejected promises that bypass the `bin/cordova` `.catch()` are caught and exit with code 1 (mirrors the existing `uncaughtException` handler)
- **`src/cli.js`**: Return result from `printHelp()` so the promise chain resolves with the help text
- **`bin/cordova`**: No changes to the existing `.catch()` — `process.exitCode` is the correct mechanism for graceful exit

## Test plan

- [ ] Run `cordova build` with invalid platform — verify non-zero exit code
- [ ] Trigger an unhandled rejection path — verify non-zero exit code
- [ ] Run `cordova help` — verify output is printed and process exits cleanly